### PR TITLE
fix(cli): use local bin to install

### DIFF
--- a/src/client/acontext-cli/README.md
+++ b/src/client/acontext-cli/README.md
@@ -13,11 +13,28 @@ A lightweight command-line tool for quickly creating Acontext projects with temp
 
 ## Installation
 
+### User Installation (No sudo required - Recommended)
+
+By default, the CLI installs to `~/.acontext/bin` and automatically updates your shell profile (`.bashrc`, `.zshrc`, etc.):
+
 ```bash
 # Install script (Linux, macOS, WSL)
 curl -fsSL https://install.acontext.io | sh
+```
 
-# Or with Homebrew (macOS)
+After installation, restart your shell or run `source ~/.bashrc` (or `~/.zshrc` for zsh).
+
+### System-wide Installation (Requires sudo)
+
+For system-wide installation to `/usr/local/bin`:
+
+```bash
+curl -fsSL https://install.acontext.io | sh -s -- --system
+```
+
+### Homebrew (macOS)
+
+```bash
 brew install acontext/tap/acontext-cli
 ```
 


### PR DESCRIPTION

# Why we need this PR?
acontext-cli installation requires sudo, this pr removes this requirement.

# Describe your solution
Install cli binary to ~/.acontext/bin and add this path to `PATH`

# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [x] CLI Tool
- [ ] Documentation
- [ ] Other: ...


# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.