### PR TITLE
ci: add cross-platform validation for Linux, macOs, and Windows

### DIFF
--- a/.github/workflows/cross-platform-check.yml
+++ b/.github/workflows/cross-platform-check.yml
@@ -23,16 +23,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache-dependency-path: src/server/api/go/go.sum
+          cache-dependency-path: src/client/acontext-cli/go.sum
 
       - name: Install Dependencies
-        working-directory: src/server/api/go
+        working-directory: src/client/acontext-cli
         run: go mod download
 
       - name: Build Binary
-        working-directory: src/server/api/go
-        run: go build -v -o acontext ./cmd/server/main.go
+        working-directory: src/client/acontext-cli
+        run: go build -v -o acontext .
 
       - name: Run Tests (with Race Detector)
-        working-directory: src/server/api/go
+        working-directory: src/client/acontext-cli
         run: go test -v -race ./...


### PR DESCRIPTION
Github Action workflow to ensure the acontext CLI remains stable across diff operating systems

so while implementing disk features (grep,glob) I noticed the need to verify file-system logic on non-Linux env.

This Pipeline automates that process

Key changes

1.  Multi-OS matrix. It will validate build and tests on ubuntu-latest, macos-latest and windows-latest
2.  Race Detection. It will run go test with `-race` flag that will catch concurrency bugs early.
3.  Dependency Caching. So optimizing for the nested project structure ( `src/server/api/go`) to ensure fast execution
4.  Safety timeouts. Includes a 10minute timeout to prevent runaway processes

So this would and will act a quality gate for my pending PR and all future contributions