### PR TITLE
update(landingpage): integrate skill learning narrative across pages

### DIFF
--- a/landingpage/src/app/(frontend)/product/page.tsx
+++ b/landingpage/src/app/(frontend)/product/page.tsx
@@ -11,7 +11,7 @@ const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'https://acontext.io'
 export const metadata: Metadata = {
   title: 'Product - Acontext',
   description:
-    'Explore Acontext features - Context Data Platform for AI Agents with multi-modal storage, observability, and experience learning',
+    'Explore Acontext features - Context Data Platform that Learns Skills with multi-modal storage, observability, and automatic skill learning',
   alternates: {
     canonical: `${baseUrl}/product`,
   },
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default function ProductPage() {
   const softwareJsonLd = createSoftwareApplicationJsonLd(
     'Acontext',
-    'Context Data Platform for AI Agents - Unifies multi-modal context data storage, observability, and experience learning for production agents.',
+    'Context Data Platform that Learns Skills - Unifies multi-modal context data storage, observability, and automatic skill learning for production agents.',
     baseUrl,
     {
       applicationCategory: 'BusinessApplication',

--- a/landingpage/src/components/animation/demos/skills-demo.tsx
+++ b/landingpage/src/components/animation/demos/skills-demo.tsx
@@ -4,14 +4,13 @@ import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import {
   Sparkles,
-  Upload,
-  Package,
-  FileText,
-  FolderOpen,
-  Play,
   Check,
-  Terminal,
   BookOpen,
+  Brain,
+  CheckCircle2,
+  RefreshCw,
+  FileText,
+  Plus,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ToolCallLog } from './shared'
@@ -20,31 +19,31 @@ import { ToolCallLog } from './shared'
 
 type Stage =
   | 'init'
-  | 'show-package'
-  | 'uploading'
-  | 'uploaded'
-  | 'logged-upload'
-  | 'catalog'
-  | 'logged-catalog'
-  | 'sandbox-mount'
-  | 'logged-mount'
-  | 'executing'
-  | 'success'
-  | 'logged-success'
+  | 'show-task'
+  | 'task-done'
+  | 'attach'
+  | 'logged-attach'
+  | 'distilling'
+  | 'logged-distill'
+  | 'skill-update'
+  | 'logged-update'
+  | 'skill-create'
+  | 'logged-create'
+  | 'complete'
 
 const TIMELINE: Record<Stage, number> = {
   'init': 0,
-  'show-package': 600,
-  'uploading': 1400,
-  'uploaded': 2800,
-  'logged-upload': 3400,
-  'catalog': 4200,
-  'logged-catalog': 5000,
-  'sandbox-mount': 5800,
-  'logged-mount': 6600,
-  'executing': 7400,
-  'success': 9200,
-  'logged-success': 10000,
+  'show-task': 500,
+  'task-done': 1500,
+  'attach': 2500,
+  'logged-attach': 3200,
+  'distilling': 4000,
+  'logged-distill': 5200,
+  'skill-update': 6200,
+  'logged-update': 7000,
+  'skill-create': 8000,
+  'logged-create': 8800,
+  'complete': 10000,
 }
 
 const STAGES: Stage[] = Object.keys(TIMELINE) as Stage[]
@@ -52,39 +51,38 @@ const STAGES: Stage[] = Object.keys(TIMELINE) as Stage[]
 // ─── Tool calls ─────────────────────────────────────────────────────────────
 
 const TOOL_CALLS = [
-  { id: '1', message: 'Uploaded skill: data-extraction', label: 'Skills', icon: Upload },
-  { id: '2', message: 'Skill available in catalog', label: 'Skills', icon: Sparkles },
-  { id: '3', message: 'Mounted to sandbox env-42', label: 'Sandbox', icon: Package },
-  { id: '4', message: 'Executed successfully', label: 'Skills', icon: Check, iconClassName: 'text-emerald-400' },
+  { id: '1', message: 'Session attached to Learning Space', label: 'Learning', icon: Sparkles },
+  { id: '2', message: 'Distilling task outcomes...', label: 'Learning', icon: Brain },
+  { id: '3', message: 'Updated skill: deployment-sop', label: 'Skills', icon: RefreshCw },
+  { id: '4', message: 'Created skill: api-docs-checklist', label: 'Skills', icon: Plus },
 ]
 
 const STAGE_TO_LOG: Record<Stage, number> = {
-  'init': 0, 'show-package': 0, 'uploading': 0,
-  'uploaded': 0, 'logged-upload': 1,
-  'catalog': 1, 'logged-catalog': 2,
-  'sandbox-mount': 2, 'logged-mount': 3,
-  'executing': 3, 'success': 3, 'logged-success': 4,
+  'init': 0, 'show-task': 0, 'task-done': 0,
+  'attach': 0, 'logged-attach': 1,
+  'distilling': 1, 'logged-distill': 2,
+  'skill-update': 2, 'logged-update': 3,
+  'skill-create': 3, 'logged-create': 4,
+  'complete': 4,
 }
 
-// ─── Skill package files ─────────────────────────────────────────────────────
+// ─── Skill entries ──────────────────────────────────────────────────────────
 
-const SKILL_FILES = [
-  { name: 'SKILL.md', icon: BookOpen, type: 'instructions' },
-  { name: 'scripts/extract.py', icon: Play, type: 'script' },
-  { name: 'resources/template.json', icon: FileText, type: 'resource' },
-]
+interface SkillEntry {
+  name: string
+  status: 'default' | 'updated' | 'new'
+  entries: number
+}
 
 // ─── Main Skills Demo ───────────────────────────────────────────────────────
 
 export function SkillsDemo() {
   const [stage, setStage] = useState<Stage>('init')
   const [logCount, setLogCount] = useState(0)
-  const [uploadProgress, setUploadProgress] = useState(0)
 
   useEffect(() => {
     setStage('init')
     setLogCount(0)
-    setUploadProgress(0)
 
     const timers: ReturnType<typeof setTimeout>[] = []
     for (const [s, delay] of Object.entries(TIMELINE)) {
@@ -101,52 +99,41 @@ export function SkillsDemo() {
     return () => timers.forEach(clearTimeout)
   }, [])
 
-  // Upload progress bar
-  useEffect(() => {
-    if (stage !== 'uploading') return
-    setUploadProgress(0)
-    const start = Date.now()
-    const dur = 1200
-    const tick = () => {
-      const p = Math.min((Date.now() - start) / dur, 1)
-      setUploadProgress(p)
-      if (p < 1) requestAnimationFrame(tick)
-    }
-    requestAnimationFrame(tick)
-  }, [stage])
-
   const si = STAGES.indexOf(stage)
-  const showPackage = si >= STAGES.indexOf('show-package')
-  const isUploading = si >= STAGES.indexOf('uploading')
-  const isUploaded = si >= STAGES.indexOf('uploaded')
-  const showCatalog = si >= STAGES.indexOf('catalog')
-  const showSandbox = si >= STAGES.indexOf('sandbox-mount')
-  const isExecuting = si >= STAGES.indexOf('executing')
-  const showSuccess = si >= STAGES.indexOf('success')
+  const showTask = si >= STAGES.indexOf('show-task')
+  const taskDone = si >= STAGES.indexOf('task-done')
+  const showAttach = si >= STAGES.indexOf('attach')
+  const isDistilling = si >= STAGES.indexOf('distilling')
+  const showSkillUpdate = si >= STAGES.indexOf('skill-update')
+  const showSkillCreate = si >= STAGES.indexOf('skill-create')
+  const isComplete = si >= STAGES.indexOf('complete')
+
+  const skills: SkillEntry[] = [
+    { name: 'daily-logs', status: 'default', entries: 12 },
+    { name: 'user-general-facts', status: 'default', entries: 8 },
+    {
+      name: 'deployment-sop',
+      status: showSkillUpdate ? 'updated' : 'default',
+      entries: showSkillUpdate ? 6 : 5,
+    },
+    ...(showSkillCreate
+      ? [{ name: 'api-docs-checklist', status: 'new' as const, entries: 1 }]
+      : []),
+  ]
 
   return (
     <div className="h-full flex items-center justify-center p-3 sm:p-4">
       <div className="w-full max-w-4xl flex flex-col lg:flex-row gap-4">
-        {/* Left: Skill flow */}
+        {/* Left: Session + Learning Space */}
         <div className="flex-3 min-w-0 flex flex-col gap-3">
-          {/* Skill Package */}
+          {/* Completed Task */}
           <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-white dark:bg-zinc-950 shadow-md dark:shadow-2xl">
             <div className="bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 flex items-center px-3 py-2">
-              <Package className="w-3.5 h-3.5 text-zinc-400 dark:text-zinc-500 mr-2" />
-              <span className="text-xs sm:text-sm text-zinc-600 dark:text-zinc-400">Skill Package</span>
-              {isUploading && !isUploaded && (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="ml-auto flex items-center gap-1.5"
-                >
-                  <Upload className="w-3 h-3 text-violet-500 animate-pulse" />
-                  <span className="text-[10px] sm:text-xs text-violet-600 dark:text-violet-400">
-                    Uploading...
-                  </span>
-                </motion.div>
-              )}
-              {isUploaded && (
+              <CheckCircle2 className="w-3.5 h-3.5 text-zinc-400 dark:text-zinc-500 mr-2" />
+              <span className="text-xs sm:text-sm text-zinc-600 dark:text-zinc-400">
+                Session Task
+              </span>
+              {taskDone && (
                 <motion.div
                   initial={{ opacity: 0, scale: 0.8 }}
                   animate={{ opacity: 1, scale: 1 }}
@@ -154,65 +141,60 @@ export function SkillsDemo() {
                 >
                   <Check className="w-3 h-3 text-emerald-500" />
                   <span className="text-[10px] sm:text-xs text-emerald-600 dark:text-emerald-400">
-                    Stored
+                    Success
                   </span>
                 </motion.div>
               )}
             </div>
             <div className="p-3 sm:p-4">
               <AnimatePresence>
-                {showPackage && (
+                {showTask && (
                   <motion.div
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     className="space-y-2"
                   >
-                    {/* Skill name header */}
-                    <div className="flex items-center gap-2 mb-3">
-                      <Sparkles className="w-4 h-4 text-violet-500" />
-                      <span className="text-xs sm:text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                        data-extraction
+                    <div className="flex items-center gap-2 p-2 border border-zinc-200/60 dark:border-zinc-800/60 bg-zinc-50/50 dark:bg-zinc-900/30 rounded">
+                      <FileText className="w-3 h-3 text-zinc-400 dark:text-zinc-500 shrink-0" />
+                      <span className="text-xs sm:text-sm text-zinc-700 dark:text-zinc-300 flex-1">
+                        Deploy API to staging
                       </span>
-                      <span className="text-[10px] text-zinc-400 dark:text-zinc-600">v1.0</span>
+                      <motion.span
+                        key={taskDone ? 'done' : 'running'}
+                        initial={{ scale: 0.8, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        className={cn(
+                          'text-[10px] sm:text-xs px-1.5 py-0.5 border font-mono uppercase',
+                          taskDone
+                            ? 'bg-emerald-100/50 dark:bg-emerald-950/50 text-emerald-600 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700'
+                            : 'bg-blue-100/50 dark:bg-blue-950/50 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700',
+                        )}
+                      >
+                        {taskDone ? 'success' : 'running'}
+                      </motion.span>
+                    </div>
+                    <div className="flex items-center gap-2 p-2 border border-zinc-200/60 dark:border-zinc-800/60 bg-zinc-50/50 dark:bg-zinc-900/30 rounded">
+                      <FileText className="w-3 h-3 text-zinc-400 dark:text-zinc-500 shrink-0" />
+                      <span className="text-xs sm:text-sm text-zinc-700 dark:text-zinc-300 flex-1">
+                        Update API documentation
+                      </span>
+                      <motion.span
+                        key={taskDone ? 'done2' : 'pending'}
+                        initial={{ scale: 0.8, opacity: 0 }}
+                        animate={{ scale: 1, opacity: 1 }}
+                        className={cn(
+                          'text-[10px] sm:text-xs px-1.5 py-0.5 border font-mono uppercase',
+                          taskDone
+                            ? 'bg-emerald-100/50 dark:bg-emerald-950/50 text-emerald-600 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700'
+                            : 'bg-zinc-200 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 border-zinc-300 dark:border-zinc-700',
+                        )}
+                      >
+                        {taskDone ? 'success' : 'pending'}
+                      </motion.span>
                     </div>
 
-                    {/* File list */}
-                    {SKILL_FILES.map((file, i) => (
-                      <motion.div
-                        key={file.name}
-                        initial={{ opacity: 0, x: -8 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{ delay: i * 0.15, type: 'spring', stiffness: 300, damping: 20 }}
-                        className="flex items-center gap-2 px-2 py-1.5 border border-zinc-200/60 dark:border-zinc-800/60 bg-zinc-50/50 dark:bg-zinc-900/30 rounded"
-                      >
-                        <file.icon className="w-3 h-3 text-zinc-400 dark:text-zinc-500 shrink-0" />
-                        <span className="text-xs text-zinc-600 dark:text-zinc-400 font-mono truncate">
-                          {file.name}
-                        </span>
-                        <span className="text-[10px] text-zinc-400 dark:text-zinc-600 ml-auto capitalize">
-                          {file.type}
-                        </span>
-                      </motion.div>
-                    ))}
-
-                    {/* Upload progress */}
-                    {isUploading && !isUploaded && (
-                      <motion.div
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        className="mt-2"
-                      >
-                        <div className="h-1 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
-                          <motion.div
-                            className="h-full bg-violet-500 rounded-full"
-                            style={{ width: `${uploadProgress * 100}%` }}
-                          />
-                        </div>
-                      </motion.div>
-                    )}
-
-                    {/* Catalog badge after upload */}
-                    {showCatalog && (
+                    {/* Attach indicator */}
+                    {showAttach && (
                       <motion.div
                         initial={{ opacity: 0, y: 8 }}
                         animate={{ opacity: 1, y: 0 }}
@@ -221,11 +203,25 @@ export function SkillsDemo() {
                       >
                         <Sparkles className="w-3 h-3 text-violet-500 dark:text-violet-400" />
                         <span className="text-[10px] sm:text-xs text-violet-600 dark:text-violet-400">
-                          Available in skill catalog
+                          Attached to Learning Space
                         </span>
-                        <span className="text-[10px] text-violet-400 dark:text-violet-600 ml-auto">
-                          3 files
-                        </span>
+                        {isDistilling && (
+                          <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            className="ml-auto flex items-center gap-1"
+                          >
+                            <motion.div
+                              animate={{ rotate: 360 }}
+                              transition={{ duration: 2, repeat: Infinity, ease: 'linear' }}
+                            >
+                              <Brain className="w-3 h-3 text-violet-400 dark:text-violet-500" />
+                            </motion.div>
+                            <span className="text-[10px] text-violet-400 dark:text-violet-500">
+                              {isComplete ? 'Done' : 'Distilling...'}
+                            </span>
+                          </motion.div>
+                        )}
                       </motion.div>
                     )}
                   </motion.div>
@@ -234,9 +230,9 @@ export function SkillsDemo() {
             </div>
           </div>
 
-          {/* Sandbox Execution */}
+          {/* Learning Space */}
           <AnimatePresence>
-            {showSandbox && (
+            {showAttach && (
               <motion.div
                 initial={{ opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -244,10 +240,11 @@ export function SkillsDemo() {
                 className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-white dark:bg-zinc-950 shadow-md dark:shadow-2xl"
               >
                 <div className="bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 flex items-center px-3 py-2">
-                  <Terminal className="w-3.5 h-3.5 text-zinc-400 dark:text-zinc-500 mr-2" />
-                  <span className="text-xs sm:text-sm text-zinc-600 dark:text-zinc-400">Sandbox</span>
-                  <span className="text-[10px] text-zinc-400 dark:text-zinc-600 ml-2 font-mono">env-42</span>
-                  {showSuccess && (
+                  <BookOpen className="w-3.5 h-3.5 text-zinc-400 dark:text-zinc-500 mr-2" />
+                  <span className="text-xs sm:text-sm text-zinc-600 dark:text-zinc-400">
+                    Learning Space
+                  </span>
+                  {isComplete && (
                     <motion.div
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
@@ -257,82 +254,60 @@ export function SkillsDemo() {
                     </motion.div>
                   )}
                 </div>
-                <div className="p-3 sm:p-4">
-                  {/* Mounted skill path */}
-                  <div className="flex items-center gap-2 mb-2">
-                    <FolderOpen className="w-3 h-3 text-zinc-400 dark:text-zinc-500" />
-                    <span className="text-[10px] sm:text-xs text-zinc-400 dark:text-zinc-500 font-mono">
-                      /skills/data-extraction/
-                    </span>
-                  </div>
-
-                  {/* Terminal output */}
-                  <div className="font-mono text-[10px] sm:text-xs space-y-0.5">
-                    <motion.p
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      className="text-zinc-400 dark:text-zinc-500"
+                <div className="p-3 sm:p-4 space-y-1.5">
+                  {skills.map((skill, i) => (
+                    <motion.div
+                      key={skill.name}
+                      initial={
+                        skill.status === 'new' ? { opacity: 0, x: -8 } : { opacity: 1, x: 0 }
+                      }
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                      className={cn(
+                        'flex items-center gap-2 px-2 py-1.5 rounded border',
+                        skill.status === 'updated'
+                          ? 'border-violet-300/50 dark:border-violet-700/50 bg-violet-50/30 dark:bg-violet-950/20'
+                          : skill.status === 'new'
+                            ? 'border-emerald-300/50 dark:border-emerald-700/50 bg-emerald-50/30 dark:bg-emerald-950/20'
+                            : 'border-zinc-200/60 dark:border-zinc-800/60 bg-zinc-50/50 dark:bg-zinc-900/30',
+                      )}
                     >
-                      $ cat SKILL.md | head -3
-                    </motion.p>
-                    <motion.p
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{ delay: 0.2 }}
-                      className="text-zinc-600 dark:text-zinc-400"
-                    >
-                      name: data-extraction
-                    </motion.p>
-                    <motion.p
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{ delay: 0.35 }}
-                      className="text-zinc-600 dark:text-zinc-400"
-                    >
-                      description: Extract structured data from docs
-                    </motion.p>
-
-                    {isExecuting && (
-                      <>
-                        <motion.p
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: 0.1 }}
-                          className="text-zinc-400 dark:text-zinc-500 mt-1"
+                      <Sparkles
+                        className={cn(
+                          'w-3 h-3 shrink-0',
+                          skill.status === 'updated'
+                            ? 'text-violet-500'
+                            : skill.status === 'new'
+                              ? 'text-emerald-500'
+                              : 'text-zinc-400 dark:text-zinc-500',
+                        )}
+                      />
+                      <span className="text-xs text-zinc-600 dark:text-zinc-400 font-mono truncate flex-1">
+                        {skill.name}
+                      </span>
+                      {skill.status === 'updated' && (
+                        <motion.span
+                          initial={{ opacity: 0, scale: 0.8 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          className="text-[10px] text-violet-500 dark:text-violet-400 font-medium"
                         >
-                          $ python scripts/extract.py --input docs/
-                        </motion.p>
-                        <motion.p
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: 0.3 }}
-                          className="text-zinc-600 dark:text-zinc-400"
+                          +1 entry
+                        </motion.span>
+                      )}
+                      {skill.status === 'new' && (
+                        <motion.span
+                          initial={{ opacity: 0, scale: 0.8 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          className="text-[10px] text-emerald-500 dark:text-emerald-400 font-medium"
                         >
-                          Processing 3 documents...
-                        </motion.p>
-                      </>
-                    )}
-
-                    {showSuccess && (
-                      <>
-                        <motion.p
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          className="text-zinc-600 dark:text-zinc-400"
-                        >
-                          Extracted 12 records to output.json
-                        </motion.p>
-                        <motion.p
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: 0.15 }}
-                          className="text-emerald-400"
-                        >
-                          Done in 0.8s
-                        </motion.p>
-                      </>
-                    )}
-                  </div>
+                          NEW
+                        </motion.span>
+                      )}
+                      <span className="text-[10px] text-zinc-400 dark:text-zinc-600">
+                        {skill.entries} entries
+                      </span>
+                    </motion.div>
+                  ))}
                 </div>
               </motion.div>
             )}

--- a/landingpage/src/components/landing/features.tsx
+++ b/landingpage/src/components/landing/features.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useRef, useEffect, useState } from 'react'
-import { Layers, HardDrive, Github, Database, Activity, Plug } from 'lucide-react'
+import { Layers, HardDrive, Database, Activity, Plug, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-type FeatureTheme = 'layers' | 'disk' | 'github' | 'database' | 'activity' | 'plug'
+type FeatureTheme = 'layers' | 'disk' | 'database' | 'activity' | 'plug' | 'sparkles'
 
 interface Feature {
   title: string
@@ -45,18 +45,18 @@ const rightFeatures: Feature[] = [
     theme: 'activity',
   },
   {
+    title: 'Self-Learning',
+    description:
+      'Attach sessions to a Learning Space and Acontext automatically distills successful task outcomes into skills — agents improve with every run without manual curation.',
+    Icon: Sparkles,
+    theme: 'sparkles',
+  },
+  {
     title: 'SDKs & Integrations',
     description:
       'Ready to use with OpenAI, Anthropic, LangGraph, Agno, and other popular agent frameworks.',
     Icon: Plug,
     theme: 'plug',
-  },
-  {
-    title: 'Open Source',
-    description:
-      'Architecture built on community standards. Every major dependency has a direct open-source alternative to ensure stack portability.',
-    Icon: Github,
-    theme: 'github',
   },
 ]
 
@@ -131,16 +131,6 @@ function FeatureCanvas({ theme, isHovered }: { theme: FeatureTheme; isHovered: b
           }))
           break
 
-        case 'github':
-          particlesRef.current = Array.from({ length: 12 }, () => ({
-            x: Math.random() * w,
-            y: Math.random() * h,
-            vx: (Math.random() - 0.5) * 0.3,
-            vy: (Math.random() - 0.5) * 0.3,
-            size: 3 + Math.random() * 2,
-          }))
-          break
-
         case 'database':
           particlesRef.current = Array.from({ length: 15 }, () => ({
             x: w * 0.3 + Math.random() * w * 0.4,
@@ -166,6 +156,17 @@ function FeatureCanvas({ theme, isHovered }: { theme: FeatureTheme; isHovered: b
             targetY: h * 0.3 + Math.floor((i + 1) / 3) * (h * 0.4),
             progress: Math.random(),
             speed: 0.005 + Math.random() * 0.005,
+          }))
+          break
+
+        case 'sparkles':
+          particlesRef.current = Array.from({ length: 20 }, () => ({
+            x: Math.random() * w,
+            y: Math.random() * h,
+            size: 1 + Math.random() * 3,
+            phase: Math.random() * Math.PI * 2,
+            speed: 0.02 + Math.random() * 0.03,
+            vy: -0.2 - Math.random() * 0.3,
           }))
           break
       }
@@ -246,47 +247,6 @@ function FeatureCanvas({ theme, isHovered }: { theme: FeatureTheme; isHovered: b
             const y = centerY + Math.sin(d.angle) * d.radius
             ctx.beginPath()
             ctx.arc(x, y, d.size, 0, Math.PI * 2)
-            ctx.fillStyle = color(baseAlpha)
-            ctx.fill()
-          })
-          break
-        }
-
-        case 'github': {
-          const nodes = particlesRef.current as {
-            x: number
-            y: number
-            vx: number
-            vy: number
-            size: number
-          }[]
-          // Move nodes
-          nodes.forEach((n) => {
-            n.x += n.vx * speedMultiplier
-            n.y += n.vy * speedMultiplier
-            if (n.x < 0 || n.x > w) n.vx *= -1
-            if (n.y < 0 || n.y > h) n.vy *= -1
-          })
-
-          // Draw connections
-          ctx.strokeStyle = color(baseAlpha * 0.4)
-          ctx.lineWidth = 0.5
-          nodes.forEach((n1, i) => {
-            nodes.slice(i + 1).forEach((n2) => {
-              const dist = Math.hypot(n1.x - n2.x, n1.y - n2.y)
-              if (dist < 80) {
-                ctx.beginPath()
-                ctx.moveTo(n1.x, n1.y)
-                ctx.lineTo(n2.x, n2.y)
-                ctx.stroke()
-              }
-            })
-          })
-
-          // Draw nodes
-          nodes.forEach((n) => {
-            ctx.beginPath()
-            ctx.arc(n.x, n.y, n.size, 0, Math.PI * 2)
             ctx.fillStyle = color(baseAlpha)
             ctx.fill()
           })
@@ -427,6 +387,31 @@ function FeatureCanvas({ theme, isHovered }: { theme: FeatureTheme; isHovered: b
           })
           break
         }
+
+        case 'sparkles': {
+          const stars = particlesRef.current as {
+            x: number
+            y: number
+            size: number
+            phase: number
+            speed: number
+            vy: number
+          }[]
+          stars.forEach((s) => {
+            s.phase += s.speed * speedMultiplier
+            s.y += s.vy * speedMultiplier
+            if (s.y < -10) {
+              s.y = h + 10
+              s.x = Math.random() * w
+            }
+            const alpha = ((Math.sin(s.phase) + 1) / 2) * baseAlpha
+            ctx.beginPath()
+            ctx.arc(s.x, s.y, s.size, 0, Math.PI * 2)
+            ctx.fillStyle = color(alpha)
+            ctx.fill()
+          })
+          break
+        }
       }
 
       time++
@@ -507,7 +492,7 @@ export function Features() {
             Platform Capabilities
           </h2>
           <p className="text-muted-foreground max-w-2xl mx-auto">
-            The production-grade infrastructure your agents need — storage, observability, integrations, and more.
+            The production-grade infrastructure your agents need — storage, observability, self-learning, and more.
           </p>
         </div>
 

--- a/landingpage/src/components/landing/header.tsx
+++ b/landingpage/src/components/landing/header.tsx
@@ -353,6 +353,25 @@ export function Header() {
                             <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
                           </div>
                         </Link>
+                        <Link
+                          href="https://docs.acontext.io/learn/self-learning"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block px-3 py-1 hover:bg-muted/50 transition-colors group"
+                          aria-label="Learning Spaces (opens in new tab)"
+                        >
+                          <div className="flex items-center justify-between gap-2.5">
+                            <div className="flex items-center gap-2.5">
+                              <div className="w-8 h-8 rounded bg-pink-500/10 shrink-0 flex items-center justify-center">
+                                <Sparkles className="h-4 w-4 text-pink-500" />
+                              </div>
+                              <span className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+                                Learning Spaces
+                              </span>
+                            </div>
+                            <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                          </div>
+                        </Link>
                       </div>
                       {/* Right Column */}
                       <div className="flex-1 py-1">
@@ -888,6 +907,25 @@ export function Header() {
                     <span className="flex w-full items-center justify-between">
                       <span className="flex items-center gap-x-0.5 text-base font-normal text-foreground">
                         Product Spotlight
+                      </span>
+                      <Sparkles className="size-5 opacity-50" />
+                    </span>
+                  </div>
+                </div>
+              </Link>
+              <Link
+                href="https://docs.acontext.io/learn/self-learning"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={handleMobileLinkClick}
+                className="group outline-none w-full"
+                aria-label="Learning Spaces (opens in new tab)"
+              >
+                <div className="flex gap-x-1 text-center font-sans transition justify-center items-center shrink-0 select-none group-focus:outline-none group-disabled:opacity-75 group-disabled:pointer-events-none disabled:opacity-50 text-xs border-b border-border py-3 w-full">
+                  <div className="w-full transition">
+                    <span className="flex w-full items-center justify-between">
+                      <span className="flex items-center gap-x-0.5 text-base font-normal text-foreground">
+                        Learning Spaces
                       </span>
                       <Sparkles className="size-5 opacity-50" />
                     </span>

--- a/landingpage/src/components/landing/hero.tsx
+++ b/landingpage/src/components/landing/hero.tsx
@@ -194,7 +194,7 @@ export function Hero() {
           style={{ transformStyle: 'preserve-3d' }}
         >
           <p className="text-lg sm:text-xl text-muted-foreground hero-tagline">
-            Context Data Platform for AI Agents
+            Context Data Platform that Learns Skills
           </p>
           <h1
             ref={titleRef}
@@ -210,7 +210,7 @@ export function Hero() {
           className="max-w-3xl mx-auto space-y-3 sm:space-y-4 animate-fade-in animation-delay-600 px-2 sm:px-0 will-change-transform"
         >
           <p className="text-sm sm:text-base md:text-lg text-muted-foreground leading-relaxed">
-            Think of it as Supabase, but purpose-built for agent context
+            Think of it as Supabase for agent context — with built-in skill learning that improves your agents over time.
           </p>
           <div className="cursor-pointer flex flex-wrap items-center justify-center gap-x-2 sm:gap-x-3 gap-y-2 text-xs sm:text-sm md:text-base text-muted-foreground/80">
             <span className="px-2 sm:px-3 py-1 sm:py-1.5 rounded-md bg-muted/50 border border-border/50 transition-all duration-200 hover:bg-muted/80 hover:border-foreground/40 hover:text-foreground/90">

--- a/landingpage/src/components/landing/overview.tsx
+++ b/landingpage/src/components/landing/overview.tsx
@@ -38,11 +38,11 @@ const TABS: FeatureTab[] = [
   {
     id: 'skills',
     title: 'Learn',
-    subtitle: 'Skill Sandbox',
-    description: 'Package reusable agent skills with instructions and scripts. Mount and execute them in isolated sandboxes.',
+    subtitle: 'Skill Learning',
+    description: 'Attach a session to a Learning Space and Acontext automatically distills successful task outcomes into reusable skills — your agents improve with every run.',
     color: TAB_COLORS.skills,
     icon: Sparkles,
-    duration: 12_000,
+    duration: 11_000,
     Demo: SkillsDemo,
   },
   {

--- a/landingpage/src/components/product/features.tsx
+++ b/landingpage/src/components/product/features.tsx
@@ -30,6 +30,7 @@ import {
   Edit3,
   FileCode,
   Gauge,
+  Sparkles,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -112,6 +113,13 @@ const availableFeatures: Feature[] = [
     icon: Layers,
     status: 'available',
     docsUrl: 'https://docs.acontext.io/store/skill',
+  },
+  {
+    title: 'Learning Spaces',
+    description: 'Automatic skill learning from agent sessions — distills task outcomes into reusable skills',
+    icon: Sparkles,
+    status: 'available',
+    docsUrl: 'https://docs.acontext.io/learn/self-learning',
   },
   {
     title: 'Task Monitoring',

--- a/landingpage/src/components/product/hero.tsx
+++ b/landingpage/src/components/product/hero.tsx
@@ -387,7 +387,7 @@ export function Hero() {
           <span className="hero-text-gradient">Context Data Platform</span>
         </h1>
         <p className="text-lg sm:text-xl md:text-2xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-          Store, observe, and learn from your AI agents
+          Store, observe, and let your agents learn and grow from every run
         </p>
       </div>
     </section>

--- a/landingpage/src/components/product/spotlight.tsx
+++ b/landingpage/src/components/product/spotlight.tsx
@@ -3,12 +3,12 @@
 import { useState } from 'react'
 import {
   MessageSquare,
-  FileText,
   BarChart3,
   BookOpen,
   ArrowRight,
   Terminal,
   HardDrive,
+  Sparkles,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -63,12 +63,12 @@ const spotlightCards: SpotlightCard[] = [
     gradient: 'from-indigo-500/20 to-blue-500/20',
   },
   {
-    title: 'Dashboard',
+    title: 'Learning Spaces',
     description:
-      'View Context, Artifacts, Tasks and Skills in a unified dashboard. Monitor agent performance and manage resources with an intuitive interface.',
-    icon: FileText,
-    href: 'https://dash.acontext.io',
-    gradient: 'from-purple-500/20 to-pink-500/20',
+      'Create a learning space and attach sessions. Acontext automatically extracts successful task patterns and builds reusable skills from each run.',
+    icon: Sparkles,
+    href: 'https://docs.acontext.io/learn/self-learning',
+    gradient: 'from-pink-500/20 to-rose-500/20',
   },
 ]
 


### PR DESCRIPTION


# Why we need this PR?
> Align the landing page and product page messaging with the new self-learning skills capability, replacing the old "skill package upload" story with the session-based "Learning Spaces" narrative.

# Describe your solution
- Updated hero taglines, descriptions, and metadata across landing and product pages to emphasize "Context Data Platform that Learns Skills"
- Rewrote the Skills Demo animation from a package-upload flow to a session → attach → distill → skill-update/create lifecycle
- Added "Learning Spaces" navigation links in the header (desktop mega-menu and mobile drawer)
- Added a "Learning Spaces" feature card in the product features grid
- Replaced the "Dashboard" spotlight card with "Learning Spaces"
- Added a `sparkles` particle animation case in the features canvas
- Updated overview tab copy for the skills section

# Implementation Tasks
Please ensure your pull request meets the following requirements:
- [x] Update hero copy on landing page (tagline + subtitle)
- [x] Update product page metadata and hero copy
- [x] Rewrite skills-demo animation with learning-space flow
- [x] Add "Learning Spaces" to header navigation (desktop + mobile)
- [x] Add "Learning Spaces" feature card in product features
- [x] Replace Dashboard spotlight card with Learning Spaces
- [x] Add sparkles particle animation in features canvas
- [x] Update overview tab description for skills

# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: Landing Page / Product Page

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.


Made with [Cursor](https://cursor.com)