### PR TITLE
Update CLOUDFLARE_WORKER_URL in acontext-cli

### DIFF
--- a/src/client/acontext-cli/internal/docker/docker-compose.yaml
+++ b/src/client/acontext-cli/internal/docker/docker-compose.yaml
@@ -173,7 +173,7 @@ services:
       S3_ENDPOINT: http://acontext-server-seaweedfs:9000
       OTEL_EXPORTER_OTLP_ENDPOINT: acontext-server-jaeger:4317
       SANDBOX_TYPE: cloudflare
-      CLOUDFLARE_WORKER_URL: http://localhost:8787
+      CLOUDFLARE_WORKER_URL: ${CLOUDFLARE_WORKER_URL:-http://host.docker.internal:8787}
     ports:
       - "${CORE_EXPORT_PORT:-8019}:8000"
     volumes:


### PR DESCRIPTION
update CLOUDFLARE_WORKER_URL to use environment variable  or host.docker.internal



# Why we need this PR?
Failed to create sandbox when start server with acontext server up:
APIError: 500: failed to create sandbox

# Describe your solution
CLOUDFLARE_WORKER_URL is no longer hardcoded to localhost:8787, which is not available for acontext-server-core in docker


# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [x] CLI Tool
- [ ] Documentation
- [ ] Other: ...


# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.