### PR TITLE
chore: add dependabot and CI test workflow for sandbox cloudflare worker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,19 @@ updates:
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
+    directory: "/src/server/sandbox/cloudflare"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "deps"
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
     directory: "/src/packages/sandbox-cloudflare"
     schedule:
       interval: "weekly"

--- a/.github/workflows/package-test-sandbox-cloudflare.yaml
+++ b/.github/workflows/package-test-sandbox-cloudflare.yaml
@@ -1,0 +1,42 @@
+name: Sandbox Cloudflare Worker Test
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "src/server/sandbox/cloudflare/**"
+      - ".github/workflows/package-test-sandbox-cloudflare.yaml"
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - "src/server/sandbox/cloudflare/**"
+      - ".github/workflows/package-test-sandbox-cloudflare.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: src/server/sandbox/cloudflare
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build check (dry-run deploy)
+        run: npx wrangler deploy --dry-run --outdir=dist


### PR DESCRIPTION
# Why we need this PR?

`src/server/sandbox/cloudflare` has npm dependencies (`@cloudflare/sandbox`, `@cloudflare/workers-types`, `wrangler`, etc.) but was missing both Dependabot configuration and a CI test workflow. This means dependency updates had no automated validation.

# Describe your solution

1. **Added Dependabot entry** for `src/server/sandbox/cloudflare` in `.github/dependabot.yml` — weekly npm dependency checks targeting the `deps` branch, consistent with existing entries.
2. **Added a CI test workflow** (`package-test-sandbox-cloudflare.yaml`) that runs on push/PR to `dev` when sandbox cloudflare files change. It performs `npm install` + `wrangler deploy --dry-run` to verify TypeScript compilation and bundling without requiring Cloudflare credentials.

# Implementation Tasks

- [x] Add npm Dependabot entry for `src/server/sandbox/cloudflare`
- [x] Create `package-test-sandbox-cloudflare.yaml` CI workflow with build check

# Impact Areas

- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: CI / DevOps (`src/server/sandbox/cloudflare`)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

Made with [Cursor](https://cursor.com)