### PR TITLE
fix: preserve image_url parts in OpenAI converter on message retrieval

### DIFF
--- a/src/server/api/go/internal/pkg/converter/converter_test.go
+++ b/src/server/api/go/internal/pkg/converter/converter_test.go
@@ -585,6 +585,41 @@ func TestGetConvertedMessagesOutput_MixedMetas(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{}, result.Metas[2])
 }
 
+func TestGetAssetURL_LookupBySHA256(t *testing.T) {
+	t.Run("resolves by SHA256 key", func(t *testing.T) {
+		asset := &model.Asset{
+			S3Key:  "parts/project-id/abc.json",
+			SHA256: "deadbeef1234",
+		}
+		publicURLs := map[string]service.PublicURL{
+			"deadbeef1234": {URL: "https://cdn.example.com/signed-url"},
+		}
+
+		result := GetAssetURL(asset, publicURLs)
+		assert.Equal(t, "https://cdn.example.com/signed-url", result)
+	})
+
+	t.Run("nil asset returns empty", func(t *testing.T) {
+		result := GetAssetURL(nil, map[string]service.PublicURL{
+			"key": {URL: "https://example.com"},
+		})
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("missing SHA256 in map returns empty", func(t *testing.T) {
+		asset := &model.Asset{
+			S3Key:  "parts/project-id/abc.json",
+			SHA256: "not-in-map",
+		}
+		publicURLs := map[string]service.PublicURL{
+			"deadbeef1234": {URL: "https://cdn.example.com/signed-url"},
+		}
+
+		result := GetAssetURL(asset, publicURLs)
+		assert.Equal(t, "", result)
+	})
+}
+
 func TestGetConvertedMessagesOutput_EmptyMessages_HasEmptyMetas(t *testing.T) {
 	messages := []model.Message{}
 

--- a/src/server/api/go/internal/pkg/converter/openai.go
+++ b/src/server/api/go/internal/pkg/converter/openai.go
@@ -66,6 +66,11 @@ func (c *OpenAIConverter) convertToUserMessage(msg model.Message, publicURLs map
 			contentParts = append(contentParts, openai.TextContentPart(part.Text))
 		case model.PartTypeImage:
 			imageURL := GetAssetURL(part.Asset, publicURLs)
+			if imageURL == "" && part.Meta != nil {
+				if url := part.GetMetaString(model.MetaKeyURL); url != "" {
+					imageURL = url
+				}
+			}
 			if imageURL != "" {
 				detail := part.GetMetaString(model.MetaKeyDetail)
 				imgParam := openai.ChatCompletionContentPartImageImageURLParam{

--- a/src/server/api/go/internal/pkg/converter/openai_test.go
+++ b/src/server/api/go/internal/pkg/converter/openai_test.go
@@ -111,6 +111,98 @@ func TestOpenAIConverter_Convert_ThinkingDowngradedToText(t *testing.T) {
 	})
 }
 
+func TestOpenAIConverter_Convert_ImagePartFromMetaURL(t *testing.T) {
+	converter := &OpenAIConverter{}
+
+	t.Run("image with external URL in meta", func(t *testing.T) {
+		messages := []model.Message{
+			createTestMessage(model.RoleUser, []model.Part{
+				{Type: model.PartTypeText, Text: "What is in this image?"},
+				{
+					Type: model.PartTypeImage,
+					Meta: map[string]any{
+						model.MetaKeyURL:    "https://example.com/cat.png",
+						model.MetaKeyDetail: "high",
+					},
+				},
+			}, nil),
+		}
+
+		result, err := converter.Convert(messages, nil)
+		require.NoError(t, err)
+
+		msgs := result.([]openai.ChatCompletionMessageParamUnion)
+		require.Len(t, msgs, 1)
+
+		user := msgs[0].OfUser
+		require.NotNil(t, user)
+
+		parts := user.Content.OfArrayOfContentParts
+		require.Len(t, parts, 2, "should have text + image parts")
+
+		assert.NotNil(t, parts[0].OfText)
+		assert.Equal(t, "What is in this image?", parts[0].OfText.Text)
+
+		assert.NotNil(t, parts[1].OfImageURL)
+		assert.Equal(t, "https://example.com/cat.png", parts[1].OfImageURL.ImageURL.URL)
+		assert.Equal(t, "high", parts[1].OfImageURL.ImageURL.Detail)
+	})
+
+	t.Run("image with data URL in meta", func(t *testing.T) {
+		dataURL := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+		messages := []model.Message{
+			createTestMessage(model.RoleUser, []model.Part{
+				{
+					Type: model.PartTypeImage,
+					Meta: map[string]any{
+						model.MetaKeyURL:    dataURL,
+						model.MetaKeyDetail: "low",
+					},
+				},
+			}, nil),
+		}
+
+		result, err := converter.Convert(messages, nil)
+		require.NoError(t, err)
+
+		msgs := result.([]openai.ChatCompletionMessageParamUnion)
+		require.Len(t, msgs, 1)
+
+		user := msgs[0].OfUser
+		require.NotNil(t, user)
+
+		parts := user.Content.OfArrayOfContentParts
+		require.Len(t, parts, 1, "should have image part")
+
+		assert.NotNil(t, parts[0].OfImageURL)
+		assert.Equal(t, dataURL, parts[0].OfImageURL.ImageURL.URL)
+		assert.Equal(t, "low", parts[0].OfImageURL.ImageURL.Detail)
+	})
+
+	t.Run("image with nil asset and no meta URL is skipped", func(t *testing.T) {
+		messages := []model.Message{
+			createTestMessage(model.RoleUser, []model.Part{
+				{Type: model.PartTypeText, Text: "Hello"},
+				{Type: model.PartTypeImage, Meta: map[string]any{}},
+			}, nil),
+		}
+
+		result, err := converter.Convert(messages, nil)
+		require.NoError(t, err)
+
+		msgs := result.([]openai.ChatCompletionMessageParamUnion)
+		require.Len(t, msgs, 1)
+
+		user := msgs[0].OfUser
+		require.NotNil(t, user)
+
+		parts := user.Content.OfArrayOfContentParts
+		require.Len(t, parts, 1, "empty image should be skipped, leaving only text")
+		assert.NotNil(t, parts[0].OfText)
+		assert.Equal(t, "Hello", parts[0].OfText.Text)
+	})
+}
+
 func TestOpenAIConverter_Convert_ToolResult(t *testing.T) {
 	converter := &OpenAIConverter{}
 

--- a/src/server/api/go/internal/pkg/converter/utils.go
+++ b/src/server/api/go/internal/pkg/converter/utils.go
@@ -23,7 +23,7 @@ func GetAssetURL(asset *model.Asset, publicURLs map[string]service.PublicURL) st
 	if asset == nil {
 		return ""
 	}
-	if publicURL, ok := publicURLs[asset.S3Key]; ok {
+	if publicURL, ok := publicURLs[asset.SHA256]; ok {
 		return publicURL.URL
 	}
 	return ""


### PR DESCRIPTION

# Why we need this PR?
> Users reported that multimodal messages with `image_url` content parts are silently dropped when stored and retrieved through the Acontext API. The AI can see images during the current turn (direct passthrough), but Acontext history loses all image parts on store/retrieve, breaking context retention across sessions.

# Describe your solution

**Bug 1 (Primary):** The OpenAI converter (`converter/openai.go`) only checked `GetAssetURL(part.Asset, publicURLs)` for image parts. When images are stored via URL (not file upload), `Part.Asset` is `nil`, so `GetAssetURL` returns `""` and the entire image part is silently skipped. The Anthropic and Gemini converters already had a fallback to `Part.Meta["url"]` — the OpenAI converter was missing it.

**Bug 2 (Secondary):** `GetAssetURL` in `converter/utils.go` looked up `publicURLs[asset.S3Key]`, but the map is keyed by `asset.SHA256` (populated in `service/session.go`). This key mismatch meant even uploaded file assets would fail URL resolution.

**Fix:** Added the `Meta["url"]` fallback to the OpenAI converter (matching Anthropic/Gemini), and corrected the `GetAssetURL` lookup key from `S3Key` to `SHA256`.

# Implementation Tasks
- [x] Add `Part.Meta["url"]` fallback in OpenAI converter's `convertToUserMessage` for image parts
- [x] Fix `GetAssetURL` map key from `asset.S3Key` to `asset.SHA256`
- [x] Add unit tests for URL-based image parts (external URL, data URL, empty meta)
- [x] Add unit tests for `GetAssetURL` SHA256 key lookup
- [x] Verify all existing converter tests pass (50/50)

# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [x] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [ ] Other: ...

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

Made with [Cursor](https://cursor.com)