### PR TITLE
fix(openclaw): add openclaw.plugin.json manifest to fix plugin installation

### DIFF
--- a/src/packages/openclaw/README.md
+++ b/src/packages/openclaw/README.md
@@ -26,15 +26,26 @@ export ACONTEXT_API_KEY=sk-ac-your-api-key
 Add to your `openclaw.json`:
 
 ```json5
-// plugins.entries
-"acontext": {
-  "enabled": true,
-  "config": {
-    "apiKey": "${ACONTEXT_API_KEY}",
-    "userId": "your-user-id"
+{
+  plugins: {
+    // Select Acontext as the active memory plugin
+    slots: {
+      memory: "acontext"
+    },
+    entries: {
+      "acontext": {
+        enabled: true,
+        config: {
+          "apiKey": "${ACONTEXT_API_KEY}",
+          "userId": "your-user-id"
+        }
+      }
+    }
   }
 }
 ```
+
+> **Note:** OpenClaw only loads one memory plugin at a time. Setting `plugins.slots.memory` to `"acontext"` replaces the default (`memory-core`). To switch back, set it to `"memory-core"` or `"none"`.
 
 Restart the gateway:
 

--- a/src/packages/openclaw/openclaw.plugin.json
+++ b/src/packages/openclaw/openclaw.plugin.json
@@ -1,0 +1,81 @@
+{
+  "id": "acontext",
+  "kind": "memory",
+  "name": "Acontext Skill Memory",
+  "description": "Acontext skill memory — auto-capture, auto-learn, sync skills to OpenClaw native directory",
+  "uiHints": {
+    "apiKey": {
+      "label": "Acontext API Key",
+      "sensitive": true,
+      "placeholder": "sk-ac-...",
+      "help": "API key from dash.acontext.io (or use ${ACONTEXT_API_KEY})"
+    },
+    "baseUrl": {
+      "label": "API Base URL",
+      "placeholder": "https://api.acontext.app/api/v1",
+      "advanced": true,
+      "help": "Acontext API base URL (override for self-hosted deployments)"
+    },
+    "userId": {
+      "label": "User ID",
+      "placeholder": "default",
+      "help": "Scope sessions and skills per user"
+    },
+    "learningSpaceId": {
+      "label": "Learning Space ID",
+      "advanced": true,
+      "help": "Explicit Learning Space ID (auto-created if omitted)"
+    },
+    "skillsDir": {
+      "label": "Skills Directory",
+      "placeholder": "~/.openclaw/skills",
+      "advanced": true,
+      "help": "Local directory where learned skills are synced for native OpenClaw loading"
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Store conversation messages to Acontext after each agent turn"
+    },
+    "autoLearn": {
+      "label": "Auto-Learn",
+      "help": "Trigger skill distillation from sessions automatically"
+    },
+    "minTurnsForLearn": {
+      "label": "Min Turns for Auto-Learn",
+      "placeholder": "4",
+      "advanced": true,
+      "help": "Minimum conversation turns before triggering auto-learn"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": {
+        "type": "string"
+      },
+      "baseUrl": {
+        "type": "string"
+      },
+      "userId": {
+        "type": "string"
+      },
+      "learningSpaceId": {
+        "type": "string"
+      },
+      "skillsDir": {
+        "type": "string"
+      },
+      "autoCapture": {
+        "type": "boolean"
+      },
+      "autoLearn": {
+        "type": "boolean"
+      },
+      "minTurnsForLearn": {
+        "type": "number"
+      }
+    },
+    "required": []
+  }
+}

--- a/src/packages/openclaw/package.json
+++ b/src/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acontext/openclaw",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"type": "module",
 	"main": "./index.ts",
 	"description": "Acontext skill memory plugin for OpenClaw — auto-capture, auto-learn, native skill sync",
@@ -23,6 +23,7 @@
 	},
 	"files": [
 		"index.ts",
+		"openclaw.plugin.json",
 		"openclaw-plugin-sdk.d.ts",
 		"README.md",
 		"PUBLISH.md"


### PR DESCRIPTION
# Why we need this PR?

`openclaw plugins install @acontext/openclaw` fails/hangs because OpenClaw 2026.3.2 requires every plugin to ship an `openclaw.plugin.json` manifest file with `id` and `configSchema` fields ([docs](https://docs.openclaw.ai/plugins/manifest)). Our `@acontext/openclaw@0.1.1` package was missing this file entirely, causing config validation to block.

Confirmed by comparing with `@mem0/openclaw-mem0@0.1.2` which ships `openclaw.plugin.json` (4.2KB) and installs correctly.

# Describe your solution

Add `openclaw.plugin.json` with:
- `id: "acontext"` and `kind: "memory"` — plugin identity
- `configSchema` — JSON Schema for all 8 config fields (`apiKey`, `baseUrl`, `userId`, `learningSpaceId`, `skillsDir`, `autoCapture`, `autoLearn`, `minTurnsForLearn`), matching `ALLOWED_KEYS` in `index.ts`
- `uiHints` — labels, placeholders, and sensitive flags for the OpenClaw Control UI

Also update README to document that `plugins.slots.memory = "acontext"` is required since OpenClaw only loads one memory plugin at a time.

# Implementation Tasks

- [x] Create `openclaw.plugin.json` with `id`, `kind`, `configSchema`, `uiHints`
- [x] Add `openclaw.plugin.json` to `package.json` `files` array
- [x] Bump version `0.1.1` → `0.1.2`
- [x] Update README with `plugins.slots.memory` config instructions
- [x] Verify `npm pack --dry-run` includes the new manifest file

# Impact Areas

- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: OpenClaw Plugin (`@acontext/openclaw`)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

Made with [Cursor](https://cursor.com)