### PR TITLE
fix(openclaw): align plugin with upstream SDK types, hooks, and manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ When releasing a new version of an SDK or package, follow these steps in order:
 1. **Bump the version number** in the package manifest:
    - TypeScript SDK: update `"version"` in `src/client/acontext-ts/package.json`
    - Python SDK: update `version` in `src/client/acontext-py/pyproject.toml`
-   - OpenClaw Plugin: update `"version"` in `src/packages/openclaw/package.json`
+   - OpenClaw Plugin: update `"version"` in `src/packages/openclaw/package.json` **and** `version` in `src/packages/openclaw/index.ts` (the plugin object)
    - Sandbox Cloudflare: update `"version"` in `src/packages/sandbox-cloudflare/package.json`
 2. **Regenerate the lock file** so it stays in sync:
    - TypeScript SDK: run `npm install` in `src/client/acontext-ts/` (updates `package-lock.json`)

--- a/src/packages/openclaw/index.ts
+++ b/src/packages/openclaw/index.ts
@@ -16,7 +16,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Type } from "@sinclair/typebox";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 
 // ============================================================================
 // Types
@@ -141,8 +141,8 @@ export const configSchema = {
 // ============================================================================
 
 export interface BridgeLogger {
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
+  info: (message: string) => void;
+  warn: (message: string) => void;
 }
 
 type SkillMeta = {
@@ -582,6 +582,7 @@ export class AcontextBridge {
 const acontextPlugin = {
   id: "acontext",
   name: "Acontext Skill Memory",
+  version: "0.1.3",
   description:
     "Acontext skill memory — auto-capture, auto-learn, sync skills to OpenClaw native directory",
   kind: "memory" as const,
@@ -889,6 +890,30 @@ const acontextPlugin = {
       }
     });
 
+    // Flush + learn before session is compacted or reset to avoid losing data
+    if (cfg.autoCapture) {
+      const flushAndLearnIfActive = async () => {
+        if (!currentAcontextSessionId || !cfg.autoLearn) return;
+        try {
+          await bridge.flush(currentAcontextSessionId);
+          const learningId = await bridge.learnFromSession(currentAcontextSessionId);
+          if (learningId) {
+            api.logger.info(`acontext: pre-clear learn triggered (learning: ${learningId})`);
+          }
+        } catch (err) {
+          api.logger.warn(`acontext: pre-clear flush/learn failed: ${String(err)}`);
+        }
+      };
+
+      api.on("before_compaction", async (_event, _ctx) => {
+        await flushAndLearnIfActive();
+      });
+
+      api.on("before_reset", async (_event, _ctx) => {
+        await flushAndLearnIfActive();
+      });
+    }
+
     // Auto-capture + auto-learn: store messages and trigger learning
     if (cfg.autoCapture) {
       api.on("agent_end", async (event, ctx) => {
@@ -984,7 +1009,7 @@ const acontextPlugin = {
 
     api.registerService({
       id: "acontext",
-      start: () => {
+      start: (_ctx) => {
         api.logger.info(
           `acontext: service started (user: ${cfg.userId}, autoCapture: ${cfg.autoCapture}, autoLearn: ${cfg.autoLearn})`,
         );
@@ -992,7 +1017,7 @@ const acontextPlugin = {
           api.logger.warn(`acontext: initial skill sync failed: ${String(err)}`);
         });
       },
-      stop: () => {
+      stop: (_ctx) => {
         api.logger.info("acontext: service stopped");
       },
     });

--- a/src/packages/openclaw/jest.config.js
+++ b/src/packages/openclaw/jest.config.js
@@ -5,6 +5,7 @@ export default {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
     // Stub out external modules that aren't available in test env
+    "^openclaw/plugin-sdk/core$": "<rootDir>/tests/__mocks__/openclaw-plugin-sdk.ts",
     "^openclaw/plugin-sdk$": "<rootDir>/tests/__mocks__/openclaw-plugin-sdk.ts",
     "^@acontext/acontext$": "<rootDir>/tests/__mocks__/acontext-sdk.ts",
   },

--- a/src/packages/openclaw/openclaw-plugin-sdk.d.ts
+++ b/src/packages/openclaw/openclaw-plugin-sdk.d.ts
@@ -1,21 +1,300 @@
 /**
- * Stub type declarations for openclaw/plugin-sdk.
+ * Type declarations for openclaw/plugin-sdk.
+ *
+ * Based on the upstream OpenClaw plugin SDK types from
+ * https://github.com/openclaw/openclaw (src/plugins/types.ts).
+ *
  * OpenClaw plugin SDK types are only available at runtime inside the
  * OpenClaw gateway. This declaration file satisfies the type checker
  * for builds and tests outside of that environment.
  */
-declare module "openclaw/plugin-sdk" {
-  export interface OpenClawPluginApi {
-    pluginConfig: unknown;
-    logger: {
-      info: (...args: unknown[]) => void;
-      warn: (...args: unknown[]) => void;
-      error: (...args: unknown[]) => void;
+declare module "openclaw/plugin-sdk/core" {
+  // ---------------------------------------------------------------------------
+  // Logger
+  // ---------------------------------------------------------------------------
+
+  export type PluginLogger = {
+    debug?: (message: string) => void;
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Config Schema
+  // ---------------------------------------------------------------------------
+
+  export type PluginConfigValidation =
+    | { ok: true; value?: unknown }
+    | { ok: false; errors: string[] };
+
+  export type OpenClawPluginConfigSchema = {
+    safeParse?: (value: unknown) => {
+      success: boolean;
+      data?: unknown;
+      error?: { issues?: Array<{ path: unknown[]; message: string }> };
     };
-    resolvePath: (p: string) => string;
-    registerTool: (toolDef: any, opts?: any) => void;
-    registerCli: (handler: any, opts?: any) => void;
-    registerService: (service: any) => void;
-    on: (event: string, handler: (...args: any[]) => any) => void;
-  }
+    parse?: (value: unknown) => unknown;
+    validate?: (value: unknown) => PluginConfigValidation;
+    uiHints?: Record<string, unknown>;
+    jsonSchema?: Record<string, unknown>;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Tool Types
+  // ---------------------------------------------------------------------------
+
+  export type AnyAgentTool = Record<string, unknown> & {
+    name: string;
+    description?: string;
+    parameters?: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    execute?: (...args: any[]) => any;
+  };
+
+  export type OpenClawPluginToolContext = {
+    config?: unknown;
+    workspaceDir?: string;
+    agentDir?: string;
+    agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    messageChannel?: string;
+    agentAccountId?: string;
+    requesterSenderId?: string;
+    senderIsOwner?: boolean;
+    sandboxed?: boolean;
+  };
+
+  export type OpenClawPluginToolFactory = (
+    ctx: OpenClawPluginToolContext,
+  ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
+
+  export type OpenClawPluginToolOptions = {
+    name?: string;
+    names?: string[];
+    optional?: boolean;
+  };
+
+  // ---------------------------------------------------------------------------
+  // CLI Types
+  // ---------------------------------------------------------------------------
+
+  export type OpenClawPluginCliContext = {
+    program: unknown;
+    config: unknown;
+    workspaceDir?: string;
+    logger: PluginLogger;
+  };
+
+  export type OpenClawPluginCliRegistrar = (
+    ctx: OpenClawPluginCliContext,
+  ) => void | Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // Service Types
+  // ---------------------------------------------------------------------------
+
+  export type OpenClawPluginServiceContext = {
+    config: unknown;
+    workspaceDir?: string;
+    stateDir: string;
+    logger: PluginLogger;
+  };
+
+  export type OpenClawPluginService = {
+    id: string;
+    start: (ctx: OpenClawPluginServiceContext) => void | Promise<void>;
+    stop?: (ctx: OpenClawPluginServiceContext) => void | Promise<void>;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Hook Types
+  // ---------------------------------------------------------------------------
+
+  export type PluginHookName =
+    | "before_model_resolve"
+    | "before_prompt_build"
+    | "before_agent_start"
+    | "llm_input"
+    | "llm_output"
+    | "agent_end"
+    | "before_compaction"
+    | "after_compaction"
+    | "before_reset"
+    | "message_received"
+    | "message_sending"
+    | "message_sent"
+    | "before_tool_call"
+    | "after_tool_call"
+    | "tool_result_persist"
+    | "before_message_write"
+    | "session_start"
+    | "session_end"
+    | "subagent_spawning"
+    | "subagent_delivery_target"
+    | "subagent_spawned"
+    | "subagent_ended"
+    | "gateway_start"
+    | "gateway_stop";
+
+  export type PluginHookAgentContext = {
+    agentId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    workspaceDir?: string;
+    messageProvider?: string;
+    trigger?: string;
+    channelId?: string;
+  };
+
+  export type PluginHookBeforeAgentStartEvent = {
+    prompt: string;
+    messages?: unknown[];
+  };
+
+  export type PluginHookBeforeAgentStartResult = {
+    systemPrompt?: string;
+    prependContext?: string;
+    modelOverride?: string;
+    providerOverride?: string;
+  };
+
+  export type PluginHookAgentEndEvent = {
+    messages: unknown[];
+    success: boolean;
+    error?: string;
+    durationMs?: number;
+  };
+
+  export type PluginHookBeforeCompactionEvent = {
+    messageCount: number;
+    compactingCount?: number;
+    tokenCount?: number;
+    messages?: unknown[];
+    sessionFile?: string;
+  };
+
+  export type PluginHookBeforeResetEvent = {
+    sessionFile?: string;
+    messages?: unknown[];
+    reason?: string;
+  };
+
+  export type PluginHookHandlerMap = {
+    before_model_resolve: (event: unknown, ctx: PluginHookAgentContext) => unknown;
+    before_prompt_build: (event: unknown, ctx: PluginHookAgentContext) => unknown;
+    before_agent_start: (
+      event: PluginHookBeforeAgentStartEvent,
+      ctx: PluginHookAgentContext,
+    ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
+    llm_input: (event: unknown, ctx: PluginHookAgentContext) => unknown;
+    llm_output: (event: unknown, ctx: PluginHookAgentContext) => unknown;
+    agent_end: (
+      event: PluginHookAgentEndEvent,
+      ctx: PluginHookAgentContext,
+    ) => Promise<void> | void;
+    before_compaction: (
+      event: PluginHookBeforeCompactionEvent,
+      ctx: PluginHookAgentContext,
+    ) => Promise<void> | void;
+    after_compaction: (event: unknown, ctx: PluginHookAgentContext) => unknown;
+    before_reset: (
+      event: PluginHookBeforeResetEvent,
+      ctx: PluginHookAgentContext,
+    ) => Promise<void> | void;
+    message_received: (event: unknown, ctx: unknown) => unknown;
+    message_sending: (event: unknown, ctx: unknown) => unknown;
+    message_sent: (event: unknown, ctx: unknown) => unknown;
+    before_tool_call: (event: unknown, ctx: unknown) => unknown;
+    after_tool_call: (event: unknown, ctx: unknown) => unknown;
+    tool_result_persist: (event: unknown, ctx: unknown) => unknown;
+    before_message_write: (event: unknown, ctx: unknown) => unknown;
+    session_start: (event: unknown, ctx: unknown) => unknown;
+    session_end: (event: unknown, ctx: unknown) => unknown;
+    subagent_spawning: (event: unknown, ctx: unknown) => unknown;
+    subagent_delivery_target: (event: unknown, ctx: unknown) => unknown;
+    subagent_spawned: (event: unknown, ctx: unknown) => unknown;
+    subagent_ended: (event: unknown, ctx: unknown) => unknown;
+    gateway_start: (event: unknown, ctx: unknown) => unknown;
+    gateway_stop: (event: unknown, ctx: unknown) => unknown;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Command Types
+  // ---------------------------------------------------------------------------
+
+  export type OpenClawPluginCommandDefinition = {
+    name: string;
+    description: string;
+    acceptsArgs?: boolean;
+    requireAuth?: boolean;
+    handler: (ctx: unknown) => unknown;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Plugin API
+  // ---------------------------------------------------------------------------
+
+  export type OpenClawPluginApi = {
+    id: string;
+    name: string;
+    version?: string;
+    description?: string;
+    source: string;
+    config: unknown;
+    pluginConfig?: Record<string, unknown>;
+    runtime: unknown;
+    logger: PluginLogger;
+    registerTool: (
+      tool: AnyAgentTool | OpenClawPluginToolFactory,
+      opts?: OpenClawPluginToolOptions,
+    ) => void;
+    registerHook: (
+      events: string | string[],
+      handler: (...args: unknown[]) => unknown,
+      opts?: unknown,
+    ) => void;
+    registerHttpRoute: (params: unknown) => void;
+    registerChannel: (registration: unknown) => void;
+    registerGatewayMethod: (method: string, handler: unknown) => void;
+    registerCli: (
+      registrar: OpenClawPluginCliRegistrar,
+      opts?: { commands?: string[] },
+    ) => void;
+    registerService: (service: OpenClawPluginService) => void;
+    registerProvider: (provider: unknown) => void;
+    registerCommand: (command: OpenClawPluginCommandDefinition) => void;
+    resolvePath: (input: string) => string;
+    on: <K extends PluginHookName>(
+      hookName: K,
+      handler: PluginHookHandlerMap[K],
+      opts?: { priority?: number },
+    ) => void;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Plugin Definition
+  // ---------------------------------------------------------------------------
+
+  export type PluginKind = "memory";
+
+  export type OpenClawPluginDefinition = {
+    id?: string;
+    name?: string;
+    description?: string;
+    version?: string;
+    kind?: PluginKind;
+    configSchema?: OpenClawPluginConfigSchema;
+    register?: (api: OpenClawPluginApi) => void | Promise<void>;
+    activate?: (api: OpenClawPluginApi) => void | Promise<void>;
+  };
+}
+
+/**
+ * Legacy monolithic import path — re-exports everything from core.
+ * Kept for backward compatibility with existing external plugins.
+ */
+declare module "openclaw/plugin-sdk" {
+  export * from "openclaw/plugin-sdk/core";
 }

--- a/src/packages/openclaw/openclaw.plugin.json
+++ b/src/packages/openclaw/openclaw.plugin.json
@@ -55,27 +55,33 @@
         "type": "string"
       },
       "baseUrl": {
-        "type": "string"
+        "type": "string",
+        "default": "https://api.acontext.app/api/v1"
       },
       "userId": {
-        "type": "string"
+        "type": "string",
+        "default": "default"
       },
       "learningSpaceId": {
         "type": "string"
       },
       "skillsDir": {
-        "type": "string"
+        "type": "string",
+        "default": "~/.openclaw/skills"
       },
       "autoCapture": {
-        "type": "boolean"
+        "type": "boolean",
+        "default": true
       },
       "autoLearn": {
-        "type": "boolean"
+        "type": "boolean",
+        "default": true
       },
       "minTurnsForLearn": {
-        "type": "number"
+        "type": "number",
+        "default": 4
       }
     },
-    "required": []
+    "required": ["apiKey"]
   }
 }

--- a/src/packages/openclaw/package.json
+++ b/src/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@acontext/openclaw",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"type": "module",
 	"main": "./index.ts",
 	"description": "Acontext skill memory plugin for OpenClaw — auto-capture, auto-learn, native skill sync",
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@acontext/acontext": "^0.1.14",
-		"@sinclair/typebox": "0.34.47"
+		"@sinclair/typebox": "^0.34.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^30.0.0",

--- a/src/packages/openclaw/tests/__mocks__/openclaw-plugin-sdk.ts
+++ b/src/packages/openclaw/tests/__mocks__/openclaw-plugin-sdk.ts
@@ -1,16 +1,30 @@
 /**
- * Stub for openclaw/plugin-sdk — only the type is imported in index.ts.
+ * Stub for openclaw/plugin-sdk — matches the upstream OpenClawPluginApi surface.
  */
 export interface OpenClawPluginApi {
-  pluginConfig: unknown;
+  id: string;
+  name: string;
+  version?: string;
+  description?: string;
+  source: string;
+  config: unknown;
+  pluginConfig?: Record<string, unknown>;
+  runtime: unknown;
   logger: {
-    info: (...args: unknown[]) => void;
-    warn: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
+    debug?: (message: string) => void;
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
   };
-  resolvePath: (p: string) => string;
   registerTool: (...args: unknown[]) => void;
+  registerHook: (...args: unknown[]) => void;
+  registerHttpRoute: (...args: unknown[]) => void;
+  registerChannel: (...args: unknown[]) => void;
+  registerGatewayMethod: (...args: unknown[]) => void;
   registerCli: (...args: unknown[]) => void;
   registerService: (...args: unknown[]) => void;
-  on: (event: string, handler: (...args: unknown[]) => unknown) => void;
+  registerProvider: (...args: unknown[]) => void;
+  registerCommand: (...args: unknown[]) => void;
+  resolvePath: (input: string) => string;
+  on: (event: string, handler: (...args: unknown[]) => unknown, opts?: unknown) => void;
 }

--- a/src/packages/openclaw/tests/plugin.test.ts
+++ b/src/packages/openclaw/tests/plugin.test.ts
@@ -626,8 +626,11 @@ describe("plugin registration", () => {
     expect(toolNames).not.toContain("acontext_read_skill");
 
     // before_agent_start for skill sync check + agent_end for capture
+    // + before_compaction and before_reset for pre-clear learning
     expect(hooks["before_agent_start"]).toHaveLength(1);
     expect(hooks["agent_end"]).toHaveLength(1);
+    expect(hooks["before_compaction"]).toHaveLength(1);
+    expect(hooks["before_reset"]).toHaveLength(1);
 
     // CLI registered
     expect(api.registerCli).toHaveBeenCalledTimes(1);
@@ -649,8 +652,10 @@ describe("plugin registration", () => {
 
     // before_agent_start always registered (for skill sync)
     expect(hooks["before_agent_start"]).toHaveLength(1);
-    // agent_end not registered when autoCapture=false
+    // agent_end, before_compaction, before_reset not registered when autoCapture=false
     expect(hooks["agent_end"]).toBeUndefined();
+    expect(hooks["before_compaction"]).toBeUndefined();
+    expect(hooks["before_reset"]).toBeUndefined();
   });
 
   test("logs on registration", async () => {
@@ -802,10 +807,87 @@ describe("auto-capture hook", () => {
 // ============================================================================
 
 describe("plugin metadata", () => {
-  test("exports correct id and kind", async () => {
+  test("exports correct id, kind, and version", async () => {
     const { default: plugin } = await import("../index");
     expect(plugin.id).toBe("acontext");
     expect(plugin.kind).toBe("memory");
     expect(plugin.name).toBe("Acontext Skill Memory");
+    expect(plugin.version).toBe("0.1.3");
+  });
+});
+
+// ============================================================================
+// Before-Compaction / Before-Reset Hook Behavior
+// ============================================================================
+
+describe("before_compaction and before_reset hooks", () => {
+  function createMockApi(pluginConfig: unknown) {
+    const hooks: Record<string, Function[]> = {};
+    const api = {
+      pluginConfig,
+      logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+      resolvePath: (p: string) => p,
+      registerTool: jest.fn(),
+      registerCli: jest.fn(),
+      registerService: jest.fn(),
+      on: jest.fn((event: string, handler: Function) => {
+        if (!hooks[event]) hooks[event] = [];
+        hooks[event].push(handler);
+      }),
+    };
+    return { api, hooks };
+  }
+
+  test("before_compaction hook is registered when autoCapture=true", async () => {
+    const { default: plugin } = await import("../index");
+    const { api, hooks } = createMockApi({ apiKey: "sk-ac-test" });
+
+    plugin.register(api as any);
+
+    expect(hooks["before_compaction"]).toHaveLength(1);
+  });
+
+  test("before_reset hook is registered when autoCapture=true", async () => {
+    const { default: plugin } = await import("../index");
+    const { api, hooks } = createMockApi({ apiKey: "sk-ac-test" });
+
+    plugin.register(api as any);
+
+    expect(hooks["before_reset"]).toHaveLength(1);
+  });
+
+  test("before_compaction does not throw when no active session", async () => {
+    const { default: plugin } = await import("../index");
+    const { api, hooks } = createMockApi({ apiKey: "sk-ac-test" });
+
+    plugin.register(api as any);
+
+    const hook = hooks["before_compaction"][0];
+    const result = await hook({ messageCount: 10 }, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("before_reset does not throw when no active session", async () => {
+    const { default: plugin } = await import("../index");
+    const { api, hooks } = createMockApi({ apiKey: "sk-ac-test" });
+
+    plugin.register(api as any);
+
+    const hook = hooks["before_reset"][0];
+    const result = await hook({}, {});
+    expect(result).toBeUndefined();
+  });
+
+  test("hooks not registered when autoCapture=false", async () => {
+    const { default: plugin } = await import("../index");
+    const { api, hooks } = createMockApi({
+      apiKey: "sk-ac-test",
+      autoCapture: false,
+    });
+
+    plugin.register(api as any);
+
+    expect(hooks["before_compaction"]).toBeUndefined();
+    expect(hooks["before_reset"]).toBeUndefined();
   });
 });


### PR DESCRIPTION

# Why we need this PR?

Align `@acontext/openclaw` plugin with the upstream OpenClaw Plugin SDK to ensure full compatibility with the latest plugin system (types, lifecycle hooks, manifest validation, and Control UI).

# Describe your solution

Audited the plugin against the official OpenClaw plugin documentation ([Plugins](https://docs.openclaw.ai/tools/plugin), [Manifest](https://docs.openclaw.ai/plugins/manifest), [Agent Tools](https://docs.openclaw.ai/plugins/agent-tools)) and fixed all gaps:

- **SDK types**: Rewrote `openclaw-plugin-sdk.d.ts` with the full upstream type surface — `PluginHookHandlerMap`, `PluginHookName`, `OpenClawPluginService`, `OpenClawPluginCliContext`, `OpenClawPluginToolContext`, `OpenClawPluginDefinition`, etc.
- **Import path**: Migrated from `openclaw/plugin-sdk` to the recommended `openclaw/plugin-sdk/core` subpath (legacy path kept via re-export in d.ts).
- **Lifecycle hooks**: Added `before_compaction` and `before_reset` hooks that flush the active session and trigger auto-learn before data is lost.
- **Manifest**: Fixed `required: ["apiKey"]` and added `default` values for all optional config fields so the Control UI renders correctly.
- **Plugin metadata**: Added `version` field to the plugin definition object.
- **Type alignment**: Fixed `BridgeLogger` signature from `(...args: unknown[]) => void` to `(message: string) => void` to match upstream `PluginLogger`.
- **Service signature**: `start`/`stop` now accept the upstream `OpenClawPluginServiceContext` parameter.
- **Dependency**: Relaxed `@sinclair/typebox` from pinned `0.34.47` to `^0.34.0`.
- **AGENTS.md**: Updated version bump instructions to note that OpenClaw Plugin requires updating version in both `package.json` and `index.ts`.
- **Version bump**: 0.1.2 → 0.1.3.

# Implementation Tasks

- [x] Rewrite `openclaw-plugin-sdk.d.ts` with full upstream types
- [x] Migrate import path to `openclaw/plugin-sdk/core`
- [x] Add `before_compaction` and `before_reset` lifecycle hooks
- [x] Fix `openclaw.plugin.json` required field and default values
- [x] Add `version` to plugin definition
- [x] Fix `BridgeLogger` type to match upstream `PluginLogger`
- [x] Service start/stop accept context parameter
- [x] Relax `@sinclair/typebox` to `^0.34.0`
- [x] Update test mock to match full `OpenClawPluginApi` surface
- [x] Add tests for new hooks and plugin metadata
- [x] Update AGENTS.md version bump instructions
- [x] Bump version to 0.1.3

# Impact Areas

- [x] Other: OpenClaw Plugin (`src/packages/openclaw/`)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

Made with [Cursor](https://cursor.com)