### PR TITLE
feat(openclaw): deduplicate learnFromSession calls with local persistence

### DIFF
--- a/src/packages/openclaw/index.ts
+++ b/src/packages/openclaw/index.ts
@@ -145,6 +145,11 @@ export interface BridgeLogger {
   warn: (message: string) => void;
 }
 
+export type LearnResult =
+  | { status: "learned"; id: string }
+  | { status: "skipped" }
+  | { status: "error" };
+
 type SkillMeta = {
   id: string;
   name: string;
@@ -191,6 +196,8 @@ export class AcontextBridge {
   private skillsMetadata: SkillMeta[] | null = null;
   private skillsSynced = false;
   private syncInProgress: Promise<SkillMeta[]> | null = null;
+  private learnedSessions = new Set<string>();
+  private learnedSessionsLoaded = false;
   private static MANIFEST_STALE_MS = 30 * 60 * 1000; // 30 minutes
 
   constructor(private readonly cfg: AcontextConfig, dataDir: string, skillsDir: string, logger?: BridgeLogger) {
@@ -204,6 +211,29 @@ export class AcontextBridge {
 
   private manifestPath(): string {
     return path.join(this.dataDir, ".manifest.json");
+  }
+
+  private learnedSessionsPath(): string {
+    return path.join(this.dataDir, ".learned-sessions.json");
+  }
+
+  private async loadLearnedSessions(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.learnedSessionsPath(), "utf-8");
+      const ids = JSON.parse(raw) as string[];
+      for (const id of ids) this.learnedSessions.add(id);
+    } catch {
+      // file doesn't exist yet — that's fine
+    }
+  }
+
+  private async persistLearnedSessions(): Promise<void> {
+    await fs.mkdir(this.dataDir, { recursive: true });
+    await fs.writeFile(
+      this.learnedSessionsPath(),
+      JSON.stringify([...this.learnedSessions]),
+      "utf-8",
+    );
   }
 
   private skillDir(skillName: string): string {
@@ -525,7 +555,16 @@ export class AcontextBridge {
 
   // -- Learn -------------------------------------------------------------------
 
-  async learnFromSession(sessionId: string): Promise<string | null> {
+  async learnFromSession(sessionId: string): Promise<LearnResult> {
+    if (!this.learnedSessionsLoaded) {
+      await this.loadLearnedSessions();
+      this.learnedSessionsLoaded = true;
+    }
+
+    if (this.learnedSessions.has(sessionId)) {
+      return { status: "skipped" };
+    }
+
     const client = await this.ensureClient();
     const spaceId = await this.ensureLearningSpace();
     try {
@@ -533,11 +572,21 @@ export class AcontextBridge {
         spaceId,
         sessionId,
       });
+      this.learnedSessions.add(sessionId);
+      await this.persistLearnedSessions();
       this.invalidateSkillCaches();
-      return result.id;
+      return { status: "learned", id: result.id };
     } catch (err) {
-      this.logger.warn(`acontext: learnFromSession failed for ${sessionId}: ${String(err)}`);
-      return null;
+      const msg = String(err);
+      if (msg.includes("already learned")) {
+        this.learnedSessions.add(sessionId);
+        await this.persistLearnedSessions();
+        this.invalidateSkillCaches();
+        this.logger.info(`acontext: session ${sessionId} already learned, skipping`);
+        return { status: "skipped" };
+      }
+      this.logger.warn(`acontext: learnFromSession failed for ${sessionId}: ${msg}`);
+      return { status: "error" };
     }
   }
 
@@ -780,10 +829,21 @@ const acontextPlugin = {
 
             await bridge.flush(currentAcontextSessionId);
 
-            const learningId = await bridge.learnFromSession(
+            const result = await bridge.learnFromSession(
               currentAcontextSessionId,
             );
-            if (!learningId) {
+            if (result.status === "skipped") {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "This session has already been learned.",
+                  },
+                ],
+                details: { skipped: true, sessionId: currentAcontextSessionId },
+              };
+            }
+            if (result.status === "error") {
               return {
                 content: [
                   {
@@ -799,10 +859,10 @@ const acontextPlugin = {
               content: [
                 {
                   type: "text",
-                  text: `Learning triggered (id: ${learningId}). Skills will be available in ${cfg.skillsDir} once processing completes.`,
+                  text: `Learning triggered (id: ${result.id}). Skills will be available in ${cfg.skillsDir} once processing completes.`,
                 },
               ],
-              details: { learningId, sessionId: currentAcontextSessionId },
+              details: { learningId: result.id, sessionId: currentAcontextSessionId },
             };
           } catch (err) {
             return {
@@ -896,9 +956,9 @@ const acontextPlugin = {
         if (!currentAcontextSessionId || !cfg.autoLearn) return;
         try {
           await bridge.flush(currentAcontextSessionId);
-          const learningId = await bridge.learnFromSession(currentAcontextSessionId);
-          if (learningId) {
-            api.logger.info(`acontext: pre-clear learn triggered (learning: ${learningId})`);
+          const result = await bridge.learnFromSession(currentAcontextSessionId);
+          if (result.status === "learned") {
+            api.logger.info(`acontext: pre-clear learn triggered (learning: ${result.id})`);
           }
         } catch (err) {
           api.logger.warn(`acontext: pre-clear flush/learn failed: ${String(err)}`);
@@ -984,10 +1044,10 @@ const acontextPlugin = {
             bridge
               .flush(learnSessionId)
               .then(() => bridge.learnFromSession(learnSessionId))
-              .then((learningId) => {
-                if (learningId) {
+              .then((result) => {
+                if (result.status === "learned") {
                   api.logger.info(
-                    `acontext: auto-learn triggered (learning: ${learningId})`,
+                    `acontext: auto-learn triggered (learning: ${result.id})`,
                   );
                 }
               })

--- a/src/packages/openclaw/tests/plugin.test.ts
+++ b/src/packages/openclaw/tests/plugin.test.ts
@@ -17,6 +17,7 @@ import {
   AcontextBridge,
   type AcontextConfig,
   type BridgeLogger,
+  type LearnResult,
 } from "../index";
 
 // ============================================================================
@@ -567,6 +568,94 @@ describe("AcontextBridge", () => {
       (bridge as any).skillsSynced = false;
       await bridge.syncSkillsToLocal();
       expect(mockClient.learningSpaces.listSkills).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("learnFromSession", () => {
+    test("returns learned status with ID on success and persists to disk", async () => {
+      const mockClient = createMockClient();
+      const bridge = createBridge(mockClient);
+
+      const result = await bridge.learnFromSession("sess-1");
+
+      expect(result).toEqual({ status: "learned", id: "learn-1" });
+      expect(mockClient.learningSpaces.learn).toHaveBeenCalledWith({
+        spaceId: "space-1",
+        sessionId: "sess-1",
+      });
+
+      const raw = await fs.readFile(path.join(dataDir, ".learned-sessions.json"), "utf-8");
+      expect(JSON.parse(raw)).toContain("sess-1");
+    });
+
+    test("returns skipped for already-learned session (in-memory)", async () => {
+      const mockClient = createMockClient();
+      const bridge = createBridge(mockClient);
+
+      await bridge.learnFromSession("sess-1");
+      mockClient.learningSpaces.learn.mockClear();
+
+      const result = await bridge.learnFromSession("sess-1");
+
+      expect(result).toEqual({ status: "skipped" });
+      expect(mockClient.learningSpaces.learn).not.toHaveBeenCalled();
+    });
+
+    test("returns skipped for session persisted by a previous bridge instance", async () => {
+      const mockClient = createMockClient();
+      const bridge1 = createBridge(mockClient);
+      await bridge1.learnFromSession("sess-1");
+
+      mockClient.learningSpaces.learn.mockClear();
+      const bridge2 = createBridge(mockClient);
+      const result = await bridge2.learnFromSession("sess-1");
+
+      expect(result).toEqual({ status: "skipped" });
+      expect(mockClient.learningSpaces.learn).not.toHaveBeenCalled();
+    });
+
+    test("returns skipped on 'already learned' API error and persists", async () => {
+      const mockClient = createMockClient();
+      mockClient.learningSpaces.learn.mockRejectedValue(
+        new Error("APIError: session already learned by another space"),
+      );
+      const bridge = createBridge(mockClient);
+
+      const result = await bridge.learnFromSession("sess-2");
+
+      expect(result).toEqual({ status: "skipped" });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("already learned"),
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("sess-2"),
+      );
+
+      const raw = await fs.readFile(path.join(dataDir, ".learned-sessions.json"), "utf-8");
+      expect(JSON.parse(raw)).toContain("sess-2");
+
+      mockClient.learningSpaces.learn.mockClear();
+      const secondResult = await bridge.learnFromSession("sess-2");
+      expect(secondResult).toEqual({ status: "skipped" });
+      expect(mockClient.learningSpaces.learn).not.toHaveBeenCalled();
+    });
+
+    test("returns error status for other errors without persisting", async () => {
+      const mockClient = createMockClient();
+      mockClient.learningSpaces.learn.mockRejectedValue(
+        new Error("network timeout"),
+      );
+      const bridge = createBridge(mockClient);
+
+      const result = await bridge.learnFromSession("sess-3");
+
+      expect(result).toEqual({ status: "error" });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("sess-3"),
+      );
+
+      const fileExists = await fs.access(path.join(dataDir, ".learned-sessions.json")).then(() => true, () => false);
+      expect(fileExists).toBe(false);
     });
   });
 });


### PR DESCRIPTION

# Why we need this PR?

When `learnFromSession` is called multiple times for the same session (e.g. via auto-learn triggers, manual learn tool, compaction/reset hooks), each call makes a redundant API request. The server may reject duplicates, but the round-trips are wasted and produce noisy error logs.

# Describe your solution

- Introduce a `LearnResult` discriminated union type (`learned | skipped | error`) replacing the old `string | null` return.
- Track already-learned session IDs in an in-memory `Set` for fast lookup within a single bridge instance.
- Persist the set to `.learned-sessions.json` on disk so dedup survives bridge restarts.
- Gracefully handle the server-side "already learned" API error by treating it as `skipped` (logged at `info` level, not `warn`).
- Update all 4 call sites (tool handler, `flushAndLearnIfActive`, auto-learn in `agent_end`) to use the new `LearnResult` type.

# Implementation Tasks

- [x] Add `LearnResult` type and `learnedSessions` Set + disk persistence helpers
- [x] Refactor `learnFromSession` to check dedup cache before calling API
- [x] Handle server "already learned" error as `skipped` and persist
- [x] Update plugin tool handler to return distinct "skipped" message
- [x] Update `flushAndLearnIfActive` and auto-learn hooks
- [x] Add 5 unit tests covering all paths

# Impact Areas

- [x] Other: OpenClaw Plugin (`src/packages/openclaw/`)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.


Made with [Cursor](https://cursor.com)