### PR TITLE
chore(deps): add missing dependabot entries for docs and sandbox docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -124,6 +124,22 @@ updates:
           - "*"
 
   - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "deps"
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
     directory: "/landingpage"
     schedule:
       interval: "weekly"
@@ -167,6 +183,19 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/src/server/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "deps"
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/src/server/sandbox/cloudflare"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
# Why we need this PR?

Dependabot was not configured for the `docs/` and `sandbox/cloudflare` directories, leaving their dependencies unmonitored for security vulnerabilities and version updates.

# Describe your solution

Add two new entries to `.github/dependabot.yml`:

- **`/docs` (npm ecosystem)** — Weekly scans, targets `deps` branch, groups all dependencies, ignores semver-major bumps to avoid breaking changes from automated PRs
- **`/src/server/sandbox/cloudflare` (docker ecosystem)** — Weekly scans for Docker base image updates, targets `deps` branch, groups all dependencies

Both entries follow the same conventions as existing Dependabot config: `chore(deps):` commit prefix, 5 open PR limit, targeting the `deps` branch.

# Implementation Tasks
- [x] Add npm ecosystem entry for `/docs` directory with major version ignore rule
- [x] Add docker ecosystem entry for `/src/server/sandbox/cloudflare`

# Impact Areas
- [x] Documentation
- [x] Other: CI/CD infrastructure, sandbox

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.