### PR TITLE
fix(cli): only show logo for bare command and help flag

### DIFF
--- a/src/client/acontext-cli/main.go
+++ b/src/client/acontext-cli/main.go
@@ -26,25 +26,13 @@ func GetVersion() string {
 }
 
 func main() {
-	// Print logo before subcommand execution (skip for help, root, and unknown commands).
-	// Use Cobra's own command traversal to determine if a valid subcommand was provided,
-	// instead of maintaining a separate hardcoded list.
-	shouldPrintLogo := false
+	// Print logo only for `acontext -h` / `acontext --help`.
+	// The bare `acontext` (no args) case is handled by rootCmd.Run.
 	if len(os.Args) > 1 {
 		firstArg := os.Args[1]
-		isHelpFlag := firstArg == "--help" || firstArg == "-h"
-		isHelpCmd := firstArg == "help"
-		if !isHelpFlag && !isHelpCmd {
-			// Use Cobra's Find to check if the argument resolves to a registered subcommand
-			foundCmd, _, _ := rootCmd.Find(os.Args[1:])
-			if foundCmd != nil && foundCmd != rootCmd {
-				shouldPrintLogo = true
-			}
+		if firstArg == "--help" || firstArg == "-h" {
+			fmt.Println(logo.Logo)
 		}
-	}
-
-	if shouldPrintLogo {
-		fmt.Println(logo.Logo)
 	}
 
 	if cmdErr := rootCmd.Execute(); cmdErr != nil {


### PR DESCRIPTION

# Why we need this PR?

The logo/banner was printed before every subcommand execution (e.g. `acontext login`, `acontext dash projects list`), making the output noisy and cluttered.

# Describe your solution

Restrict logo display to only two entry points:
- `acontext` (no arguments) — handled by rootCmd.Run
- `acontext -h` / `acontext --help` — handled by the pre-execution check in main()

All other subcommands no longer print the logo banner.

# Implementation Tasks

- [x] Replace the subcommand-detection logic in `main()` with a simple help-flag check
- [x] Keep the existing logo display in rootCmd.Run (bare `acontext`) unchanged

# Impact Areas

- [x] CLI Tool

# Checklist

- [x] Open your pull request against the `dev` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.