### PR TITLE
fix(core): add "thinking" part type to Python Part schema

### DIFF
--- a/src/server/core/acontext_core/schema/orm/message.py
+++ b/src/server/core/acontext_core/schema/orm/message.py
@@ -37,8 +37,8 @@ class Part(BaseModel):
     """Message part model matching the GORM Part struct"""
 
     type: Literal[
-        "text", "image", "audio", "video", "file", "tool-call", "tool-result", "data"
-    ]  # "text" | "image" | "audio" | "video" | "file" | "tool-call" | "tool-result" | "data"
+        "text", "image", "audio", "video", "file", "tool-call", "tool-result", "data", "thinking"
+    ]  # "text" | "image" | "audio" | "video" | "file" | "tool-call" | "tool-result" | "data" | "thinking"
 
     # text part
     text: Optional[str] = None

--- a/src/server/core/tests/schema/test_part.py
+++ b/src/server/core/tests/schema/test_part.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+from acontext_core.schema.orm.message import Part
+
+
+VALID_PART_TYPES = [
+    "text",
+    "image",
+    "audio",
+    "video",
+    "file",
+    "tool-call",
+    "tool-result",
+    "data",
+    "thinking",
+]
+
+
+@pytest.mark.parametrize("part_type", VALID_PART_TYPES)
+def test_part_accepts_valid_types(part_type):
+    part = Part(type=part_type)
+    assert part.type == part_type
+
+
+def test_part_rejects_invalid_type():
+    with pytest.raises(ValidationError):
+        Part(type="unknown")
+
+
+def test_thinking_part_with_signature():
+    part = Part(
+        type="thinking",
+        text="Let me think about this.",
+        meta={"signature": "abc123"},
+    )
+    assert part.type == "thinking"
+    assert part.text == "Let me think about this."
+    assert part.meta["signature"] == "abc123"
+
+
+def test_thinking_part_minimal():
+    part = Part(type="thinking", text="thinking text")
+    assert part.type == "thinking"
+    assert part.meta is None


### PR DESCRIPTION
# Why we need this PR?
> This should close the issue where Python core service crashes with ValidationError when processing messages containing Anthropic extended thinking blocks.

The Go API layer already defines `PartTypeThinking = "thinking"` and correctly writes thinking blocks to S3. However, the Python core `Part.type` Literal did not include `"thinking"`, causing:

1. `_fetch_message_parts()` fails to validate parts from S3 → `message.parts` set to `None`
2. `MessageBlob(parts=None)` triggers a second ValidationError (expects `List[Part]`, not `None`)
3. All pending messages in the batch are rolled back to `failed`, creating a repeated crash loop

# Describe your solution

Add `"thinking"` to the `Part.type` Literal in `schema/orm/message.py` to align with the Go API schema definition in `model/message.go`.

# Implementation Tasks
- [x] Add `"thinking"` to `Part.type` Literal in `schema/orm/message.py`
- [x] Add unit tests for Part type validation including thinking type

# Impact Areas
- [x] Core Service

# Checklist
- [x] Open your pull request against the `dev` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)