### PR TITLE
feat(dashboard): add thinking part type rendering in messages view

### DIFF
--- a/dashboard/app/project/[id]/session/[sessionId]/messages/messages-page-client.tsx
+++ b/dashboard/app/project/[id]/session/[sessionId]/messages/messages-page-client.tsx
@@ -44,6 +44,7 @@ import {
   CheckCircle2,
   Upload,
   X,
+  Brain,
 } from "lucide-react";
 import { Project, Message, Part } from "@/types";
 import { getMessages, sendMessage, getSessionConfigs } from "../../actions";
@@ -91,6 +92,7 @@ const MessageContentPreview = ({
             {/* Part type icon */}
             <div className="shrink-0 mt-0.5">
               {part.type === "text" && <FileText className="h-3.5 w-3.5 text-muted-foreground" />}
+              {part.type === "thinking" && <Brain className="h-3.5 w-3.5 text-amber-500" />}
               {part.type === "tool-call" && <Code className="h-3.5 w-3.5 text-blue-500" />}
               {part.type === "tool-result" && <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />}
               {part.type === "image" && <ImageIcon className="h-3.5 w-3.5 text-purple-500" />}
@@ -103,6 +105,12 @@ const MessageContentPreview = ({
             <div className="flex-1 min-w-0 space-y-1">
               {part.type === "text" && part.text && (
                 <div className="text-sm text-foreground whitespace-pre-wrap wrap-break-word bg-muted/30 rounded">
+                  {part.text}
+                </div>
+              )}
+
+              {part.type === "thinking" && part.text && (
+                <div className="text-sm text-foreground whitespace-pre-wrap wrap-break-word bg-amber-50 dark:bg-amber-950/20 rounded px-2 py-1.5 border border-amber-200 dark:border-amber-900 italic">
                   {part.text}
                 </div>
               )}
@@ -977,6 +985,16 @@ export function MessagesPageClient({
                             </p>
                           </div>
                         )}
+                        {part.type === "thinking" && (
+                          <div className="space-y-2">
+                            <div className="text-xs font-medium text-amber-600 dark:text-amber-400 uppercase">
+                              Thinking
+                            </div>
+                            <p className="text-sm whitespace-pre-wrap italic text-muted-foreground bg-amber-50 dark:bg-amber-950/20 rounded px-2 py-1.5 border border-amber-200 dark:border-amber-900">
+                              {part.text}
+                            </p>
+                          </div>
+                        )}
                         {part.type === "tool-call" && part.meta && (
                           <div className="space-y-3">
                             <div className="text-xs font-medium text-muted-foreground uppercase">
@@ -1039,7 +1057,7 @@ export function MessagesPageClient({
                             </div>
                           </div>
                         )}
-                        {part.type !== "text" && part.type !== "tool-call" && part.type !== "tool-result" && (
+                        {part.type !== "text" && part.type !== "thinking" && part.type !== "tool-call" && part.type !== "tool-result" && (
                           <div className="space-y-3">
                             <div className="text-xs font-medium text-muted-foreground uppercase">
                               {part.type}

--- a/dashboard/lib/acontext/operations/message.ts
+++ b/dashboard/lib/acontext/operations/message.ts
@@ -7,7 +7,7 @@ import { Constructor, BaseClient } from "./base";
 // ==================== Type Definitions ====================
 
 export type MessageRole = "user" | "assistant";
-export type PartType = "text" | "image" | "video" | "audio" | "file" | "data" | "tool-call" | "tool-result";
+export type PartType = "text" | "thinking" | "image" | "video" | "audio" | "file" | "data" | "tool-call" | "tool-result";
 
 export interface Asset {
   sha256: string;

--- a/dashboard/lib/message-utils.ts
+++ b/dashboard/lib/message-utils.ts
@@ -7,7 +7,7 @@ export function getAllowedPartTypes(role: MessageRole): PartType[] {
   if (role === "user") {
     return ["text", "image", "audio", "video", "file", "data", "tool-result"];
   } else {
-    return ["text", "tool-call"];
+    return ["text", "thinking", "tool-call"];
   }
 }
 

--- a/dashboard/types/index.ts
+++ b/dashboard/types/index.ts
@@ -97,7 +97,7 @@ export interface GetSessionConfigsResp {
 
 // Message types
 export type MessageRole = "user" | "assistant";
-export type PartType = "text" | "image" | "video" | "audio" | "file" | "data" | "tool-call" | "tool-result";
+export type PartType = "text" | "thinking" | "image" | "video" | "audio" | "file" | "data" | "tool-call" | "tool-result";
 
 export interface Asset {
   sha256: string;


### PR DESCRIPTION


# Why we need this PR?
> Messages stored in Anthropic format can include `thinking` content blocks, but the dashboard currently skips them — they fall into the generic fallback and only show the type name without content.

# Describe your solution
Add first-class rendering for the `thinking` part type in the messages page:
- Add `"thinking"` to `PartType` union in both `types/index.ts` and `lib/acontext/operations/message.ts`
- Add `"thinking"` to allowed assistant part types in `message-utils.ts`
- Render thinking blocks with a Brain icon (amber) and amber-styled background in both the table view and the detail/expanded view
- Exclude `thinking` from the generic fallback renderer

# Implementation Tasks
- [x] Add `thinking` to `PartType` in `dashboard/types/index.ts`
- [x] Add `thinking` to `PartType` in `dashboard/lib/acontext/operations/message.ts`
- [x] Add `thinking` to allowed assistant part types in `dashboard/lib/message-utils.ts`
- [x] Add Brain icon import and thinking rendering in table view (`messages-page-client.tsx`)
- [x] Add thinking rendering in detail/expanded view (`messages-page-client.tsx`)
- [x] Exclude thinking from generic fallback condition (`messages-page-client.tsx`)

# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [x] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [ ] Other: ...

# Checklist
- [x] Open your pull request against the `dev` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.