### PR TITLE
fix(core): prevent LearningSpaceSession stuck in running state

### DIFF
--- a/src/server/core/acontext_core/service/skill_learner.py
+++ b/src/server/core/acontext_core/service/skill_learner.py
@@ -64,6 +64,8 @@ async def process_skill_distillation(body: SkillLearnTask, message: Message):
         LOG.info(
             f"Skill distillation: task {body.task_id} skipped (task not actionable or not worth learning)"
         )
+        async with DB_CLIENT.get_session_context() as db_session:
+            await LS.update_session_status(db_session, body.session_id, "completed")
         return
 
     # Publish distilled result to skill agent consumer
@@ -138,6 +140,12 @@ async def process_skill_agent(body: SkillLearnDistilled, message: Message):
             async with DB_CLIENT.get_session_context() as db_session:
                 for sid in all_session_ids:
                     await LS.update_session_status(db_session, sid, "completed")
+    except Exception as e:
+        LOG.error(
+            f"Skill agent: unhandled exception for learning space {body.learning_space_id}: {e}"
+        )
+        async with DB_CLIENT.get_session_context() as db_session:
+            await LS.update_session_status(db_session, body.session_id, "failed")
     finally:
         await release_redis_lock(body.project_id, lock_key)
 

--- a/src/server/core/tests/service/test_skill_learner_consumer.py
+++ b/src/server/core/tests/service/test_skill_learner_consumer.py
@@ -267,7 +267,7 @@ class TestDistillationConsumer:
 
     @pytest.mark.asyncio
     async def test_does_not_publish_when_task_skipped(self):
-        """Distillation consumer does NOT publish when controller returns None (task skipped)."""
+        """Distillation consumer marks session completed and does NOT publish when task skipped."""
         body = _make_body()
         ls_session = _make_ls_session()
         mock_message = MagicMock()
@@ -282,7 +282,7 @@ class TestDistillationConsumer:
             patch(
                 "acontext_core.service.skill_learner.LS.update_session_status",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_update_status,
             patch(
                 "acontext_core.service.skill_learner.SLC.process_context_distillation",
                 new_callable=AsyncMock,
@@ -303,6 +303,13 @@ class TestDistillationConsumer:
             await process_skill_distillation(body, mock_message)
 
             mock_publish.assert_not_called()
+            # Verify session is marked completed (once for "running", once for "completed")
+            assert mock_update_status.call_count == 2
+            mock_update_status.assert_any_call(
+                mock_db.get_session_context.return_value.__aenter__.return_value,
+                body.session_id,
+                "completed",
+            )
 
 
 # =============================================================================
@@ -575,11 +582,12 @@ class TestAgentConsumer:
 
     @pytest.mark.asyncio
     async def test_lock_released_on_exception(self):
-        """Agent consumer releases lock even when run_skill_agent raises an exception."""
+        """Agent consumer releases lock and marks session failed when run_skill_agent raises."""
         body = _make_distilled_body()
         mock_message = MagicMock()
 
         with (
+            patch("acontext_core.service.skill_learner.DB_CLIENT") as mock_db,
             patch(
                 "acontext_core.service.skill_learner.check_redis_lock_or_set",
                 new_callable=AsyncMock,
@@ -594,11 +602,26 @@ class TestAgentConsumer:
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("Unexpected crash"),
             ),
+            patch(
+                "acontext_core.service.skill_learner.LS.update_session_status",
+                new_callable=AsyncMock,
+            ) as mock_update_status,
         ):
-            with pytest.raises(RuntimeError):
-                await process_skill_agent(body, mock_message)
+            mock_db.get_session_context.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock()
+            )
+            mock_db.get_session_context.return_value.__aexit__ = AsyncMock(
+                return_value=False
+            )
+
+            await process_skill_agent(body, mock_message)
 
             mock_release.assert_called_once()
+            mock_update_status.assert_called_once_with(
+                mock_db.get_session_context.return_value.__aenter__.return_value,
+                body.session_id,
+                "failed",
+            )
 
     @pytest.mark.asyncio
     async def test_lock_key_uses_learning_space_id_from_message(self):


### PR DESCRIPTION
# Why we need this PR?

LearningSpaceSession can get stuck in `running` state permanently, never reaching a terminal state (`completed` or `failed`). This blocks observability and any downstream logic depending on session completion.

# Describe your solution

Two root causes fixed in `skill_learner.py`:

1. **Consumer 1 (distillation)**: When `distilled_payload is None` (task not worth learning), the consumer returned early without updating session status. Now sets status to `completed`.
2. **Consumer 2 (skill agent)**: `run_skill_agent()` exceptions propagated through `finally` which only releases the Redis lock but never updates session status. Added `except Exception` block that logs the error and sets status to `failed`.

# Implementation Tasks
- [x] Fix Consumer 1: set session status to `completed` when distillation returns None
- [x] Fix Consumer 2: add `except Exception` to catch unhandled errors and set session to `failed`
- [x] Update test `test_does_not_publish_when_task_skipped` to verify session marked `completed`
- [x] Update test `test_lock_released_on_exception` to verify exception is caught and session marked `failed`

# Impact Areas
- [x] Core Service

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)