### PR TITLE
fix(api): support developer and system roles in OpenAI normalizer/converter

### DIFF
--- a/src/server/api/go/internal/modules/model/message.go
+++ b/src/server/api/go/internal/modules/model/message.go
@@ -167,6 +167,10 @@ const (
 	// Format: [{"id": "call_xxx", "name": "function_name"}, ...]
 	GeminiCallInfoKey = "__gemini_call_info__"
 
+	// MsgMetaOriginalRole records the original provider role when it differs from the stored role.
+	// Used to round-trip roles like "system" and "developer" that map to "user" internally.
+	MsgMetaOriginalRole MetaKey = "original_role"
+
 	// UserMetaKey is the key used to store user-provided metadata within the message meta JSONB.
 	// User meta is stored in this wrapper field to isolate it from system fields like source_format.
 	UserMetaKey = "__user_meta__"

--- a/src/server/api/go/internal/pkg/converter/openai.go
+++ b/src/server/api/go/internal/pkg/converter/openai.go
@@ -17,6 +17,18 @@ func (c *OpenAIConverter) Convert(messages []model.Message, publicURLs map[strin
 	result := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
 
 	for _, msg := range messages {
+		// Check for original_role in meta to restore system/developer roles
+		if originalRole := c.getOriginalRole(msg); originalRole != "" {
+			switch originalRole {
+			case "developer":
+				result = append(result, c.convertToDeveloperMessage(msg))
+				continue
+			case "system":
+				result = append(result, c.convertToSystemMessage(msg))
+				continue
+			}
+		}
+
 		// Special handling: if user role contains only tool-result parts,
 		// convert to OpenAI's tool role
 		if msg.Role == model.RoleUser && c.isToolResultOnly(msg.Parts) {
@@ -264,6 +276,65 @@ func (c *OpenAIConverter) extractToolCallID(parts []model.Part) string {
 		}
 	}
 	return ""
+}
+
+func (c *OpenAIConverter) getOriginalRole(msg model.Message) string {
+	metaData := msg.Meta.Data()
+	if len(metaData) == 0 {
+		return ""
+	}
+	role, _ := metaData[model.MsgMetaOriginalRole].(string)
+	return role
+}
+
+func (c *OpenAIConverter) convertToDeveloperMessage(msg model.Message) openai.ChatCompletionMessageParamUnion {
+	content := c.extractTextContent(msg.Parts)
+
+	devParam := openai.ChatCompletionDeveloperMessageParam{
+		Content: openai.ChatCompletionDeveloperMessageParamContentUnion{
+			OfString: param.NewOpt(content),
+		},
+	}
+
+	if metaData := msg.Meta.Data(); len(metaData) > 0 {
+		if name, ok := metaData[model.MetaKeyName].(string); ok && name != "" {
+			devParam.Name = param.NewOpt(name)
+		}
+	}
+
+	return openai.ChatCompletionMessageParamUnion{
+		OfDeveloper: &devParam,
+	}
+}
+
+func (c *OpenAIConverter) convertToSystemMessage(msg model.Message) openai.ChatCompletionMessageParamUnion {
+	content := c.extractTextContent(msg.Parts)
+
+	sysParam := openai.ChatCompletionSystemMessageParam{
+		Content: openai.ChatCompletionSystemMessageParamContentUnion{
+			OfString: param.NewOpt(content),
+		},
+	}
+
+	if metaData := msg.Meta.Data(); len(metaData) > 0 {
+		if name, ok := metaData[model.MetaKeyName].(string); ok && name != "" {
+			sysParam.Name = param.NewOpt(name)
+		}
+	}
+
+	return openai.ChatCompletionMessageParamUnion{
+		OfSystem: &sysParam,
+	}
+}
+
+func (c *OpenAIConverter) extractTextContent(parts []model.Part) string {
+	content := ""
+	for _, part := range parts {
+		if part.Type == model.PartTypeText {
+			content += part.Text
+		}
+	}
+	return content
 }
 
 func (c *OpenAIConverter) extractToolResultContent(parts []model.Part) string {

--- a/src/server/api/go/internal/pkg/converter/openai_test.go
+++ b/src/server/api/go/internal/pkg/converter/openai_test.go
@@ -222,3 +222,73 @@ func TestOpenAIConverter_Convert_ToolResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
+func TestConvertDeveloperMessageRoundTrip(t *testing.T) {
+	converter := &OpenAIConverter{}
+
+	messages := []model.Message{
+		createTestMessage(model.RoleUser, []model.Part{
+			{Type: model.PartTypeText, Text: "You must always respond in JSON."},
+		}, map[string]any{
+			model.MsgMetaSourceFormat:    "openai",
+			model.MsgMetaOriginalRole: "developer",
+		}),
+	}
+
+	result, err := converter.Convert(messages, nil)
+	require.NoError(t, err)
+
+	msgs := result.([]openai.ChatCompletionMessageParamUnion)
+	require.Len(t, msgs, 1)
+
+	assert.NotNil(t, msgs[0].OfDeveloper, "expected OfDeveloper to be set")
+	assert.Nil(t, msgs[0].OfUser, "expected OfUser to be nil")
+	assert.False(t, param.IsOmitted(msgs[0].OfDeveloper.Content.OfString))
+	assert.Equal(t, "You must always respond in JSON.", msgs[0].OfDeveloper.Content.OfString.Value)
+}
+
+func TestConvertSystemMessageRoundTrip(t *testing.T) {
+	converter := &OpenAIConverter{}
+
+	messages := []model.Message{
+		createTestMessage(model.RoleUser, []model.Part{
+			{Type: model.PartTypeText, Text: "You are a helpful assistant."},
+		}, map[string]any{
+			model.MsgMetaSourceFormat:    "openai",
+			model.MsgMetaOriginalRole: "system",
+		}),
+	}
+
+	result, err := converter.Convert(messages, nil)
+	require.NoError(t, err)
+
+	msgs := result.([]openai.ChatCompletionMessageParamUnion)
+	require.Len(t, msgs, 1)
+
+	assert.NotNil(t, msgs[0].OfSystem, "expected OfSystem to be set")
+	assert.Nil(t, msgs[0].OfUser, "expected OfUser to be nil")
+	assert.False(t, param.IsOmitted(msgs[0].OfSystem.Content.OfString))
+	assert.Equal(t, "You are a helpful assistant.", msgs[0].OfSystem.Content.OfString.Value)
+}
+
+func TestConvertUserMessageNoOriginalRole(t *testing.T) {
+	converter := &OpenAIConverter{}
+
+	messages := []model.Message{
+		createTestMessage(model.RoleUser, []model.Part{
+			{Type: model.PartTypeText, Text: "Hello!"},
+		}, map[string]any{
+			model.MsgMetaSourceFormat: "openai",
+		}),
+	}
+
+	result, err := converter.Convert(messages, nil)
+	require.NoError(t, err)
+
+	msgs := result.([]openai.ChatCompletionMessageParamUnion)
+	require.Len(t, msgs, 1)
+
+	assert.NotNil(t, msgs[0].OfUser, "expected OfUser to be set")
+	assert.Nil(t, msgs[0].OfDeveloper, "expected OfDeveloper to be nil")
+	assert.Nil(t, msgs[0].OfSystem, "expected OfSystem to be nil")
+}

--- a/src/server/api/go/internal/pkg/normalizer/openai.go
+++ b/src/server/api/go/internal/pkg/normalizer/openai.go
@@ -26,13 +26,13 @@ func (n *OpenAINormalizer) Normalize(messageJSON json.RawMessage) (string, []ser
 	} else if message.OfAssistant != nil {
 		return normalizeOpenAIAssistantMessage(*message.OfAssistant)
 	} else if message.OfSystem != nil {
-		return "", nil, nil, fmt.Errorf("system messages are not supported. Use session-level or skill-level configuration for system prompts")
+		return normalizeOpenAISystemMessage(*message.OfSystem)
 	} else if message.OfTool != nil {
 		return normalizeOpenAIToolMessage(*message.OfTool)
 	} else if message.OfFunction != nil {
 		return normalizeOpenAIFunctionMessage(*message.OfFunction)
 	} else if message.OfDeveloper != nil {
-		return "", nil, nil, fmt.Errorf("developer messages are not supported. Use session-level or skill-level configuration for system prompts")
+		return normalizeOpenAIDeveloperMessage(*message.OfDeveloper)
 	}
 
 	return "", nil, nil, fmt.Errorf("unknown OpenAI message type")
@@ -223,6 +223,68 @@ func normalizeOpenAIContentPart(partUnion openai.ChatCompletionContentPartUnionP
 	}
 
 	return service.PartIn{}, fmt.Errorf("unsupported OpenAI content part type")
+}
+
+func normalizeOpenAISystemMessage(msg openai.ChatCompletionSystemMessageParam) (string, []service.PartIn, map[string]interface{}, error) {
+	parts := []service.PartIn{}
+
+	if !param.IsOmitted(msg.Content.OfString) {
+		parts = append(parts, service.PartIn{
+			Type: model.PartTypeText,
+			Text: msg.Content.OfString.Value,
+		})
+	} else if len(msg.Content.OfArrayOfContentParts) > 0 {
+		for _, textPart := range msg.Content.OfArrayOfContentParts {
+			parts = append(parts, service.PartIn{
+				Type: model.PartTypeText,
+				Text: textPart.Text,
+			})
+		}
+	} else {
+		return "", nil, nil, fmt.Errorf("OpenAI system message must have content")
+	}
+
+	messageMeta := map[string]interface{}{
+		model.MsgMetaSourceFormat:    "openai",
+		model.MsgMetaOriginalRole: "system",
+	}
+
+	if !param.IsOmitted(msg.Name) {
+		messageMeta[model.MetaKeyName] = msg.Name.Value
+	}
+
+	return model.RoleUser, parts, messageMeta, nil
+}
+
+func normalizeOpenAIDeveloperMessage(msg openai.ChatCompletionDeveloperMessageParam) (string, []service.PartIn, map[string]interface{}, error) {
+	parts := []service.PartIn{}
+
+	if !param.IsOmitted(msg.Content.OfString) {
+		parts = append(parts, service.PartIn{
+			Type: model.PartTypeText,
+			Text: msg.Content.OfString.Value,
+		})
+	} else if len(msg.Content.OfArrayOfContentParts) > 0 {
+		for _, textPart := range msg.Content.OfArrayOfContentParts {
+			parts = append(parts, service.PartIn{
+				Type: model.PartTypeText,
+				Text: textPart.Text,
+			})
+		}
+	} else {
+		return "", nil, nil, fmt.Errorf("OpenAI developer message must have content")
+	}
+
+	messageMeta := map[string]interface{}{
+		model.MsgMetaSourceFormat:    "openai",
+		model.MsgMetaOriginalRole: "developer",
+	}
+
+	if !param.IsOmitted(msg.Name) {
+		messageMeta[model.MetaKeyName] = msg.Name.Value
+	}
+
+	return model.RoleUser, parts, messageMeta, nil
 }
 
 func normalizeOpenAIAssistantContentPart(partUnion openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion) (service.PartIn, error) {

--- a/src/server/api/go/internal/pkg/normalizer/openai_test.go
+++ b/src/server/api/go/internal/pkg/normalizer/openai_test.go
@@ -116,33 +116,36 @@ func TestOpenAINormalizer_NormalizeFromOpenAIMessage(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "system message (not supported)",
+			name: "system message with string content",
 			input: `{
 				"role": "system",
 				"content": "You are a helpful assistant."
 			}`,
-			wantErr:     true,
-			errContains: "system messages are not supported",
+			wantRole:    model.RoleUser,
+			wantPartCnt: 1,
+			wantErr:     false,
 		},
 		{
-			name: "system message with array content (not supported)",
+			name: "system message with array content",
 			input: `{
 				"role": "system",
 				"content": [
 					{"type": "text", "text": "You are a helpful assistant."}
 				]
 			}`,
-			wantErr:     true,
-			errContains: "system messages are not supported",
+			wantRole:    model.RoleUser,
+			wantPartCnt: 1,
+			wantErr:     false,
 		},
 		{
-			name: "developer message (not supported)",
+			name: "developer message with string content",
 			input: `{
 				"role": "developer",
 				"content": "This is a developer instruction."
 			}`,
-			wantErr:     true,
-			errContains: "developer messages are not supported",
+			wantRole:    model.RoleUser,
+			wantPartCnt: 1,
+			wantErr:     false,
 		},
 		{
 			name: "tool message",
@@ -193,12 +196,12 @@ func TestOpenAINormalizer_NormalizeFromOpenAIMessage(t *testing.T) {
 			errContains: "must have content",
 		},
 		{
-			name: "system message without content (not supported)",
+			name: "system message without content",
 			input: `{
 				"role": "system"
 			}`,
 			wantErr:     true,
-			errContains: "system messages are not supported",
+			errContains: "system message must have content",
 		},
 	}
 
@@ -406,4 +409,82 @@ func TestOpenAINormalizer_MessageWithName(t *testing.T) {
 	assert.NotNil(t, messageMeta)
 	assert.Equal(t, "openai", messageMeta[model.MsgMetaSourceFormat])
 	assert.Equal(t, "Alice", messageMeta[model.MetaKeyName])
+}
+
+func TestNormalizeDeveloperMessage(t *testing.T) {
+	normalizer := &OpenAINormalizer{}
+
+	input := `{
+		"role": "developer",
+		"content": "You must always respond in JSON."
+	}`
+
+	role, parts, messageMeta, err := normalizer.NormalizeFromOpenAIMessage(json.RawMessage(input))
+
+	assert.NoError(t, err)
+	assert.Equal(t, model.RoleUser, role)
+	assert.Len(t, parts, 1)
+	assert.Equal(t, model.PartTypeText, parts[0].Type)
+	assert.Equal(t, "You must always respond in JSON.", parts[0].Text)
+	assert.Equal(t, "openai", messageMeta[model.MsgMetaSourceFormat])
+	assert.Equal(t, "developer", messageMeta[model.MsgMetaOriginalRole])
+}
+
+func TestNormalizeDeveloperMessageArrayContent(t *testing.T) {
+	normalizer := &OpenAINormalizer{}
+
+	input := `{
+		"role": "developer",
+		"content": [
+			{"type": "text", "text": "First instruction."},
+			{"type": "text", "text": "Second instruction."}
+		]
+	}`
+
+	role, parts, messageMeta, err := normalizer.NormalizeFromOpenAIMessage(json.RawMessage(input))
+
+	assert.NoError(t, err)
+	assert.Equal(t, model.RoleUser, role)
+	assert.Len(t, parts, 2)
+	assert.Equal(t, "First instruction.", parts[0].Text)
+	assert.Equal(t, "Second instruction.", parts[1].Text)
+	assert.Equal(t, "developer", messageMeta[model.MsgMetaOriginalRole])
+}
+
+func TestNormalizeSystemMessage(t *testing.T) {
+	normalizer := &OpenAINormalizer{}
+
+	input := `{
+		"role": "system",
+		"content": "You are a helpful assistant."
+	}`
+
+	role, parts, messageMeta, err := normalizer.NormalizeFromOpenAIMessage(json.RawMessage(input))
+
+	assert.NoError(t, err)
+	assert.Equal(t, model.RoleUser, role)
+	assert.Len(t, parts, 1)
+	assert.Equal(t, model.PartTypeText, parts[0].Type)
+	assert.Equal(t, "You are a helpful assistant.", parts[0].Text)
+	assert.Equal(t, "openai", messageMeta[model.MsgMetaSourceFormat])
+	assert.Equal(t, "system", messageMeta[model.MsgMetaOriginalRole])
+}
+
+func TestNormalizeDeveloperMessageWithName(t *testing.T) {
+	normalizer := &OpenAINormalizer{}
+
+	input := `{
+		"role": "developer",
+		"name": "orchestrator",
+		"content": "Follow these rules carefully."
+	}`
+
+	role, parts, messageMeta, err := normalizer.NormalizeFromOpenAIMessage(json.RawMessage(input))
+
+	assert.NoError(t, err)
+	assert.Equal(t, model.RoleUser, role)
+	assert.Len(t, parts, 1)
+	assert.Equal(t, "Follow these rules carefully.", parts[0].Text)
+	assert.Equal(t, "developer", messageMeta[model.MsgMetaOriginalRole])
+	assert.Equal(t, "orchestrator", messageMeta[model.MetaKeyName])
 }


### PR DESCRIPTION
# Why we need this PR?

Production logs show 55 out of 71 errors are `failed to normalize openai message: apijson: was not able to find discriminated union variant`. Root cause: agent frameworks (e.g. OpenClaw) include `developer` and `system` role messages in transcripts sent to the StoreMessage API. The OpenAI normalizer currently hard-rejects both roles.

# Describe your solution

Map OpenAI `developer` and `system` role messages to `user` on ingest (since the DB only allows `user`/`assistant`), and preserve the original role via a new `meta.original_role` key. On output, the converter checks this meta key and restores the correct `OfDeveloper` / `OfSystem` union variant, achieving full round-trip fidelity.

# Implementation Tasks
- [x] Add `MsgMetaOriginalRole` constant to `model/message.go`
- [x] Accept `system` and `developer` messages in OpenAI normalizer — map to `role=user` with `original_role` in meta
- [x] Restore original role in OpenAI converter — check meta and build `OfDeveloper`/`OfSystem` variants
- [x] Add normalizer tests (string content, array content, with name)
- [x] Add converter round-trip tests (developer, system, regular user unchanged)
- [x] Full test suite passes with no regressions

# Impact Areas
- [x] API Server

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)