### PR TITLE
feat(cli): improve auth validation, paginated responses, and UX

### DIFF
--- a/landingpage/public/SKILL.md
+++ b/landingpage/public/SKILL.md
@@ -23,10 +23,15 @@ Acontext provides Agent Skills as a Memory Layer for production AI agents. It pr
 
 ### 1. Install Acontext CLI
 
+If Acontext CLI is already installed, check for updates first:
+```bash
+acontext upgrade
+```
+
+If not installed, install it:
 ```bash
 curl -fsSL https://install.acontext.io | sh
 ```
-After installation, restart your shell or run `source ~/.bashrc` (or `~/.zshrc`) to make sure the CLI is in your PATH.
 
 > For system-wide installation:
 > ```bash
@@ -41,6 +46,7 @@ acontext login
 - If you're in a Interactive Terminal(TTY), this command will open a browser for OAuth, then guides you through project creation. Your API key is saved automatically.
 - If you're in a Non-interactive Terminal(agent/CI), this command will print a login URL for the user to open manually. After user completes, run `acontext login --poll` to finish authentication.
 - Set up a project via `acontext dash projects` commands. If Acontext has existing projects, make sure the user wants to use an existing project or create a new project for you.
+
 ### 3. Add Acontext to Your Agent
 
 Both plugins automatically read your API key and user email from `~/.acontext/credentials.json` and `~/.acontext/auth.json` (written by `acontext login`). No manual configuration is needed after login.
@@ -88,18 +94,22 @@ openclaw gateway
 After you have logged in, you can manage Acontext projects via CLI:
 
 1. `acontext dash projects list --json` — list available projects
-2. If user ask you to use a existing Acontext project, you should let the user to provider the api key. And then switch to this project `acontext dash projects select --project <project-id> --api-key <sk-ac-...>`. 
-3. To create, ask for an org name and project name, then run: `acontext dash projects create --name <project-name> --org <org-id>`, this command would return the API Key to you, and then select to the new project.
+2. If user ask you to use a existing Acontext project, you should let the user to provide the api key. And then switch to this project `acontext dash projects select --project <project-id> --api-key <sk-ac-...>`.
+3. To create, ask for an org name and project name, then run: `acontext dash projects create --name <project-name> --org <org-id>`. This command returns the API key and auto-saves it as the default project (no need to run `select` afterwards).
+4. After select or create, verify the project is configured correctly:
+   - Check that `~/.acontext/credentials.json` contains the project key.
+   - Run `acontext dash ping` to verify API connectivity. A successful response confirms the project is reachable.
 
 ## CLI Commands Reference
 
 
 All dashboard commands are under `acontext dash`:
 
-| Command Group   | Subcommands                         | Description                            |
-| --------------- | ----------------------------------- | -------------------------------------- |
-| `dash projects` | `list`, `select`, `create`, `stats` | Manage projects and organizations      |
-| `dash open`     | —                                   | Open the Acontext Dashboard in browser |
+| Command Group   | Subcommands                                   | Description                            |
+| --------------- | --------------------------------------------- | -------------------------------------- |
+| `dash projects` | `list`, `select`, `create`, `delete`, `stats` | Manage projects and organizations      |
+| `dash ping`     | —                                             | Verify API connectivity for the current project |
+| `dash open`     | —                                             | Open the Acontext Dashboard in browser |
 
 ### Skill Commands
 
@@ -118,7 +128,7 @@ The directory must contain a `SKILL.md` with name and description in YAML front-
 | Command            | Description                       |
 | ------------------ | --------------------------------- |
 | `acontext login`   | Log in via browser OAuth          |
-| `acontext logout`  | Clear stored credentials          |
+| `acontext logout`  | Clear stored credentials (auth.json + credentials.json) |
 | `acontext whoami`  | Show the currently logged-in user |
 | `acontext version` | Show version info                 |
 | `acontext upgrade` | Upgrade CLI to latest version     |
@@ -194,9 +204,10 @@ Restart your shell or run `source ~/.bashrc` / `source ~/.zshrc`. The installer 
 
 ### API returns 401 Unauthorized
 
-- Verify your API key with `acontext whoami`
-- Re-login with `acontext login`
-- For CI/CD, ensure `ACONTEXT_API_KEY` is set correctly
+- Run `acontext dash ping` to check if the current project key is valid
+- If ping fails, re-select with a valid API key: `acontext dash projects select --project <id> --api-key <sk-ac-...>`
+- Verify login status with `acontext whoami`
+- Re-login with `acontext login` if needed
 
 ### Claude Code plugin not working
 

--- a/src/client/acontext-cli/cmd/dash.go
+++ b/src/client/acontext-cli/cmd/dash.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/memodb-io/Acontext/acontext-cli/internal/api"
 	"github.com/memodb-io/Acontext/acontext-cli/internal/auth"
@@ -45,11 +44,9 @@ var DashCmd = &cobra.Command{
 		if err != nil || af == nil {
 			return fmt.Errorf("not logged in — run 'acontext login' first")
 		}
-		if af.IsExpired() {
-			af, err = auth.RefreshIfNeeded(af)
-			if err != nil {
-				return fmt.Errorf("session expired — run 'acontext login' again")
-			}
+		af, err = auth.ValidateAndRefresh(af)
+		if err != nil {
+			return fmt.Errorf("session invalid — run 'acontext login' again: %w", err)
 		}
 		dashUserEmail = af.User.Email
 		dashUserID = af.User.ID
@@ -58,16 +55,13 @@ var DashCmd = &cobra.Command{
 		// 2. Admin client always available (JWT only)
 		dashAdminClient = api.NewAdminClient(dashBaseURL, af.AccessToken)
 
-		// 3. Resolve API key for /api/v1 routes
+		// 3. Resolve API key for /api/v1 routes: --api-key flag > --project flag > credentials.json default
 		apiKey := dashAPIKey
-		if apiKey == "" {
-			apiKey = os.Getenv("ACONTEXT_API_KEY")
-		}
 		if apiKey == "" && dashProject != "" {
 			apiKey = auth.GetProjectKey(dashProject)
 		}
 		if apiKey == "" {
-			// Try default project
+			// Try default project from credentials.json
 			ks, _ := auth.LoadKeyStore()
 			if ks != nil && ks.DefaultProject != "" {
 				apiKey = ks.Keys[ks.DefaultProject]
@@ -86,7 +80,7 @@ var DashCmd = &cobra.Command{
 }
 
 func init() {
-	DashCmd.PersistentFlags().StringVar(&dashAPIKey, "api-key", "", "Project API key (or set ACONTEXT_API_KEY)")
+	DashCmd.PersistentFlags().StringVar(&dashAPIKey, "api-key", "", "Project API key (overrides credentials.json)")
 	DashCmd.PersistentFlags().StringVar(&dashProject, "project", "", "Project ID to use")
 	DashCmd.PersistentFlags().BoolVar(&dashJSON, "json", false, "Output as JSON")
 	DashCmd.PersistentFlags().StringVar(&dashBaseURL, "base-url", "", "API base URL override")

--- a/src/client/acontext-cli/cmd/dash_artifacts.go
+++ b/src/client/acontext-cli/cmd/dash_artifacts.go
@@ -13,8 +13,8 @@ import (
 func init() {
 	artifactsCmd := &cobra.Command{Use: "artifacts", Short: "Manage artifacts within a disk"}
 
-	lsCmd := &cobra.Command{
-		Use: "ls <disk-id>", Short: "List artifacts in a disk", Args: cobra.ExactArgs(1),
+	listCmd := &cobra.Command{
+		Use: "list <disk-id>", Short: "List artifacts in a disk", Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := requireClient()
 			if err != nil {
@@ -85,6 +85,6 @@ func init() {
 	}
 	deleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
-	artifactsCmd.AddCommand(lsCmd, uploadCmd, deleteCmd)
+	artifactsCmd.AddCommand(listCmd, uploadCmd, deleteCmd)
 	DashCmd.AddCommand(artifactsCmd)
 }

--- a/src/client/acontext-cli/cmd/dash_ping.go
+++ b/src/client/acontext-cli/cmd/dash_ping.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/memodb-io/Acontext/acontext-cli/internal/output"
+	"github.com/memodb-io/Acontext/acontext-cli/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	pingCmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Check connectivity to the Acontext API",
+		Long:  "Verifies that the current project's API key is valid and the API is reachable.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := requireClient()
+			if err != nil {
+				return err
+			}
+
+			if err := client.Ping(cmd.Context()); err != nil {
+				if dashJSON {
+					return output.RenderJSON(map[string]interface{}{
+						"status":  "error",
+						"project": dashProject,
+						"error":   err.Error(),
+					})
+				}
+				fmt.Printf("Ping failed for project %s: %v\n", dashProject, err)
+				fmt.Println()
+				fmt.Println("To fix this, re-select your project with a valid API key:")
+				fmt.Printf("  acontext dash projects select --project %s --api-key <sk-ac-...>\n", dashProject)
+				fmt.Println()
+				fmt.Println("The API key can be found on the Acontext Dashboard:")
+				fmt.Println("  https://dash.acontext.io")
+				return fmt.Errorf("ping failed")
+			}
+
+			if dashJSON {
+				return output.RenderJSON(map[string]interface{}{
+					"status":  "ok",
+					"project": dashProject,
+				})
+			}
+
+			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Project %s is reachable. Setup complete.", dashProject)))
+			return nil
+		},
+	}
+
+	DashCmd.AddCommand(pingCmd)
+}

--- a/src/client/acontext-cli/cmd/dash_projects.go
+++ b/src/client/acontext-cli/cmd/dash_projects.go
@@ -12,6 +12,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// printSetupComplete prints the common message after a project is configured.
+func printSetupComplete() {
+	fmt.Println("API key saved to ~/.acontext/credentials.json")
+	fmt.Println()
+	fmt.Println("Verify connectivity:")
+	fmt.Println("  acontext dash ping")
+}
+
 func init() {
 	projectsCmd := &cobra.Command{Use: "projects", Short: "Manage projects (requires login)"}
 
@@ -98,9 +106,7 @@ func init() {
 						return fmt.Errorf("save project key: %w", err)
 					}
 					fmt.Printf("Default project set to: %s\n", projectFlag)
-					fmt.Println("API key saved locally.")
-					fmt.Println()
-					fmt.Println("Setup complete. You can now use 'acontext dash' commands.")
+					printSetupComplete()
 					return nil
 				}
 
@@ -114,9 +120,8 @@ func init() {
 						return fmt.Errorf("rotate project key: %w", err)
 					}
 					fmt.Printf("Default project set to: %s\n", projectFlag)
-					fmt.Println("New API key generated and saved locally.")
-					fmt.Println()
-					fmt.Println("Setup complete. You can now use 'acontext dash' commands.")
+					fmt.Println("New API key generated.")
+					printSetupComplete()
 					return nil
 				}
 
@@ -136,9 +141,7 @@ func init() {
 					return fmt.Errorf("save project key: %w", err)
 				}
 				fmt.Printf("Default project set to: %s\n", projectFlag)
-				fmt.Println("API key saved locally.")
-				fmt.Println()
-				fmt.Println("Setup complete. You can now use 'acontext dash' commands.")
+				printSetupComplete()
 				return nil
 			}
 
@@ -157,7 +160,7 @@ func init() {
 				return fmt.Errorf("save project key: %w", err)
 			}
 			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Default project set to: %s", choice.Name)))
-			fmt.Println(tui.RenderInfo("API key saved locally."))
+			printSetupComplete()
 			return nil
 		},
 	}
@@ -223,24 +226,22 @@ func init() {
 			}
 
 			// 2. Link project to org via Supabase RPC
-			if err := auth.LinkProjectToOrg(dashAccessToken, orgID, name, project.ID); err != nil {
+			if err := auth.LinkProjectToOrg(dashAccessToken, orgID, name, project.ProjectID); err != nil {
 				return fmt.Errorf("link project to organization: %w", err)
 			}
 
 			if dashJSON {
 				return output.RenderJSON(project)
 			}
-			fmt.Printf("Project created: %s (%s)\n", name, project.ID)
+			fmt.Printf("Project created: %s (%s)\n", name, project.ProjectID)
 
 			// Auto-save API key and set as default
 			if project.SecretKey != "" {
-				if err := auth.SetProjectKey(project.ID, project.SecretKey); err == nil {
-					fmt.Println("API key saved locally.")
+				if err := auth.SetProjectKey(project.ProjectID, project.SecretKey); err == nil {
+					_ = auth.SetDefaultProject(project.ProjectID)
+					fmt.Printf("Default project set to: %s\n", project.ProjectID)
+					printSetupComplete()
 				}
-				_ = auth.SetDefaultProject(project.ID)
-				fmt.Printf("Default project set to: %s\n", project.ID)
-				fmt.Println()
-				fmt.Println("Setup complete. You can now use 'acontext dash' commands.")
 			}
 			return nil
 		},
@@ -287,10 +288,8 @@ func init() {
 				return output.RenderJSON(stats)
 			}
 			fmt.Printf("Sessions:  %d\n", stats.SessionCount)
-			fmt.Printf("Messages:  %d\n", stats.MessageCount)
-			fmt.Printf("Disks:     %d\n", stats.DiskCount)
+			fmt.Printf("Tasks:     %d\n", stats.TaskCount)
 			fmt.Printf("Skills:    %d\n", stats.SkillCount)
-			fmt.Printf("Users:     %d\n", stats.UserCount)
 			return nil
 		},
 	}

--- a/src/client/acontext-cli/cmd/login.go
+++ b/src/client/acontext-cli/cmd/login.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/memodb-io/Acontext/acontext-cli/internal/api"
 	"github.com/memodb-io/Acontext/acontext-cli/internal/auth"
@@ -41,7 +40,17 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// --poll flag: check for pending login
 	pollFlag, _ := cmd.Flags().GetBool("poll")
 	if pollFlag {
-		return auth.LoginPoll()
+		if err := auth.LoginPoll(); err != nil {
+			return err
+		}
+		af, _ := auth.Load()
+		if af != nil {
+			fmt.Printf("Login successful. Logged in as %s\n", af.User.Email)
+			fmt.Println("Credentials saved to ~/.acontext/auth.json")
+		}
+		fmt.Println()
+		fmt.Println("Next: set up a project. Run 'acontext dash projects list --json' to see available projects.")
+		return nil
 	}
 
 	// Check if already logged in
@@ -127,15 +136,15 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			if createErr != nil {
 				return fmt.Errorf("create project: %w", createErr)
 			}
-			if linkErr := auth.LinkProjectToOrg(af.AccessToken, orgID, projectName, project.ID); linkErr != nil {
+			if linkErr := auth.LinkProjectToOrg(af.AccessToken, orgID, projectName, project.ProjectID); linkErr != nil {
 				return fmt.Errorf("link project to organization: %w", linkErr)
 			}
-			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Project created: %s (%s)", projectName, project.ID)))
+			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Project created: %s (%s)", projectName, project.ProjectID)))
 			if project.SecretKey != "" {
-				if err := auth.SetProjectKey(project.ID, project.SecretKey); err == nil {
-					_ = auth.SetDefaultProject(project.ID)
+				if err := auth.SetProjectKey(project.ProjectID, project.SecretKey); err == nil {
+					_ = auth.SetDefaultProject(project.ProjectID)
 					fmt.Println(tui.RenderSuccess(fmt.Sprintf("Default project set to: %s", projectName)))
-					fmt.Println(tui.RenderInfo("API key saved locally."))
+					printSetupComplete()
 				}
 			}
 			return nil
@@ -151,7 +160,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		fmt.Println(tui.RenderSuccess(fmt.Sprintf("Default project set to: %s", choice.Name)))
-		fmt.Println(tui.RenderInfo("API key saved locally."))
+		printSetupComplete()
 	} else {
 		// Non-interactive (agent) mode: print URL and save state for later polling
 		loginURL, err := auth.LoginNonInteractive()
@@ -168,6 +177,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		fmt.Println("  acontext login --poll")
 		fmt.Println()
 		fmt.Println("This will retrieve the authentication tokens. Then proceed with project setup:")
+		fmt.Println()
 		fmt.Println("  1. Run 'acontext dash projects list --json' to see available projects.")
 		fmt.Println("  2. If projects exist, show them to the user as a numbered table")
 		fmt.Println("     (# | org_name | name | project_id) and ask which one to use.")
@@ -178,6 +188,9 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		fmt.Println("       acontext dash projects create --name <project-name> --org <org-id>")
 		fmt.Println("     If no orgs exist either, the user must create one at https://dash.acontext.io first.")
 		fmt.Println("     The create output includes project_id and secret_key, auto-saved as default.")
+		fmt.Println("  4. After project setup, verify connectivity:")
+		fmt.Println("       acontext dash ping")
+		fmt.Println("     If ping fails, re-run 'acontext dash projects select' with the correct API key.")
 	}
 
 	return nil
@@ -194,25 +207,20 @@ func runLogout(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println(tui.RenderSuccess("Logged out successfully"))
+	fmt.Println(tui.RenderInfo("Removed ~/.acontext/auth.json and ~/.acontext/credentials.json"))
 	return nil
 }
 
 func runWhoami(cmd *cobra.Command, args []string) error {
-	// Check ACONTEXT_API_TOKEN env var first (for CI/CD)
-	if token := os.Getenv("ACONTEXT_API_TOKEN"); token != "" {
-		fmt.Println(tui.RenderInfo("Authenticated via ACONTEXT_API_TOKEN environment variable"))
-		return nil
-	}
-
 	af, err := auth.MustLoad()
 	if err != nil {
 		return err
 	}
 
-	// Refresh if needed
-	af, err = auth.RefreshIfNeeded(af)
+	// Validate token with Supabase and refresh if needed
+	af, err = auth.ValidateAndRefresh(af)
 	if err != nil {
-		return fmt.Errorf("token refresh failed: %w", err)
+		return fmt.Errorf("session invalid — run 'acontext login' again: %w", err)
 	}
 
 	fmt.Printf("Logged in as %s\n", tui.SuccessStyle.Render(af.User.Email))

--- a/src/client/acontext-cli/cmd/skill_upload.go
+++ b/src/client/acontext-cli/cmd/skill_upload.go
@@ -35,20 +35,15 @@ var SkillCmd = &cobra.Command{
 		if err != nil || af == nil {
 			return fmt.Errorf("not logged in — run 'acontext login' first")
 		}
-		if af.IsExpired() {
-			af, err = auth.RefreshIfNeeded(af)
-			if err != nil {
-				return fmt.Errorf("session expired — run 'acontext login' again")
-			}
+		af, err = auth.ValidateAndRefresh(af)
+		if err != nil {
+			return fmt.Errorf("session invalid — run 'acontext login' again: %w", err)
 		}
 		dashUserEmail = af.User.Email
 		dashAccessToken = af.AccessToken
 
-		// Resolve API key: flag > env > default project keystore
+		// Resolve API key: flag > default project keystore
 		apiKey := skillAPIKey
-		if apiKey == "" {
-			apiKey = os.Getenv("ACONTEXT_API_KEY")
-		}
 		if apiKey == "" {
 			ks, _ := auth.LoadKeyStore()
 			if ks != nil && ks.DefaultProject != "" {
@@ -64,7 +59,7 @@ var SkillCmd = &cobra.Command{
 }
 
 func init() {
-	SkillCmd.PersistentFlags().StringVar(&skillAPIKey, "api-key", "", "Project API key (or set ACONTEXT_API_KEY)")
+	SkillCmd.PersistentFlags().StringVar(&skillAPIKey, "api-key", "", "Project API key (overrides credentials.json)")
 	SkillCmd.PersistentFlags().StringVar(&skillBaseURL, "base-url", "", "API base URL override")
 
 	uploadCmd := &cobra.Command{

--- a/src/client/acontext-cli/internal/api/admin.go
+++ b/src/client/acontext-cli/internal/api/admin.go
@@ -4,24 +4,24 @@ import "context"
 
 // --- Admin Project operations (/admin/v1/project) ---
 
-func (c *Client) AdminCreateProject(ctx context.Context, req *CreateProjectRequest) (*ProjectInfo, error) {
-	var project ProjectInfo
-	if err := c.Post(ctx, "/admin/v1/project", req, &project); err != nil {
+func (c *Client) AdminCreateProject(ctx context.Context, req *CreateProjectRequest) (*CreateProjectResponse, error) {
+	var resp CreateProjectResponse
+	if err := c.Post(ctx, "/admin/v1/project", req, &resp); err != nil {
 		return nil, err
 	}
-	return &project, nil
+	return &resp, nil
 }
 
 func (c *Client) AdminDeleteProject(ctx context.Context, projectID string) error {
 	return c.Delete(ctx, "/admin/v1/project/"+projectID, nil)
 }
 
-func (c *Client) AdminRotateKey(ctx context.Context, projectID string) (*ProjectInfo, error) {
-	var project ProjectInfo
-	if err := c.Put(ctx, "/admin/v1/project/"+projectID+"/secret_key", nil, &project); err != nil {
+func (c *Client) AdminRotateKey(ctx context.Context, projectID string) (*RotateKeyResponse, error) {
+	var resp RotateKeyResponse
+	if err := c.Put(ctx, "/admin/v1/project/"+projectID+"/secret_key", nil, &resp); err != nil {
 		return nil, err
 	}
-	return &project, nil
+	return &resp, nil
 }
 
 func (c *Client) AdminGetProjectStats(ctx context.Context, projectID string) (*ProjectStats, error) {

--- a/src/client/acontext-cli/internal/api/client_test.go
+++ b/src/client/acontext-cli/internal/api/client_test.go
@@ -11,6 +11,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// --- buildQuery tests ---
+
+func TestBuildQuery_NilParams(t *testing.T) {
+	assert.Equal(t, "", buildQuery(nil))
+}
+
+func TestBuildQuery_EmptyStruct(t *testing.T) {
+	assert.Equal(t, "", buildQuery(&ListParams{}))
+}
+
+func TestBuildQuery_UserOnly(t *testing.T) {
+	assert.Equal(t, "?user=alice", buildQuery(&ListParams{User: "alice"}))
+}
+
+func TestBuildQuery_AllFields(t *testing.T) {
+	q := buildQuery(&ListParams{User: "bob", Limit: 10, Cursor: "abc", TimeDesc: true})
+	assert.Contains(t, q, "user=bob")
+	assert.Contains(t, q, "limit=10")
+	assert.Contains(t, q, "cursor=abc")
+	assert.Contains(t, q, "time_desc=true")
+}
+
+func TestBuildQuery_LimitZeroNotIncluded(t *testing.T) {
+	q := buildQuery(&ListParams{User: "x", Limit: 0})
+	assert.NotContains(t, q, "limit")
+}
+
+// --- APIError.Error() tests ---
+
+func TestAPIError_WithMessage(t *testing.T) {
+	err := &APIError{StatusCode: 401, Message: "unauthorized"}
+	assert.Equal(t, "API error 401: unauthorized", err.Error())
+}
+
+func TestAPIError_WithoutMessage(t *testing.T) {
+	err := &APIError{StatusCode: 500}
+	assert.Equal(t, "API error 500", err.Error())
+}
+
 func TestClientGet_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Bearer sk-ac-test", r.Header.Get("Authorization"))
@@ -18,8 +57,9 @@ func TestClientGet_Success(t *testing.T) {
 
 		resp := map[string]interface{}{
 			"code": 200,
-			"data": []map[string]string{
-				{"id": "s1"},
+			"data": map[string]interface{}{
+				"id":   "s1",
+				"name": "test-project",
 			},
 		}
 		_ = json.NewEncoder(w).Encode(resp)
@@ -27,11 +67,10 @@ func TestClientGet_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, "sk-ac-test", "my-jwt")
-	var sessions []Session
-	err := client.Get(context.Background(), "/api/v1/session", &sessions)
+	var session Session
+	err := client.Get(context.Background(), "/api/v1/session/s1", &session)
 	require.NoError(t, err)
-	assert.Len(t, sessions, 1)
-	assert.Equal(t, "s1", sessions[0].ID)
+	assert.Equal(t, "s1", session.ID)
 }
 
 func TestClientGet_401(t *testing.T) {
@@ -58,12 +97,12 @@ func TestAdminClient_HeadersSet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "my-jwt-token", r.Header.Get("X-Access-Token"))
 		assert.Empty(t, r.Header.Get("Authorization"))
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "data": []interface{}{}})
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "data": map[string]interface{}{}})
 	}))
 	defer server.Close()
 
 	client := NewAdminClient(server.URL, "my-jwt-token")
-	var result []interface{}
+	var result map[string]interface{}
 	err := client.Get(context.Background(), "/admin/v1/project", &result)
 	require.NoError(t, err)
 }
@@ -101,4 +140,604 @@ func TestClientDelete(t *testing.T) {
 	client := NewClient(server.URL, "key", "jwt")
 	err := client.Delete(context.Background(), "/api/v1/session/s1", nil)
 	require.NoError(t, err)
+}
+
+// --- Paginated response tests ---
+
+func TestListSessions_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "s1", "project_id": "p1"},
+					{"id": "s2", "project_id": "p1"},
+				},
+				"next_cursor": "abc123",
+				"has_more":    true,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	sessions, err := client.ListSessions(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, sessions, 2)
+	assert.Equal(t, "s1", sessions[0].ID)
+	assert.Equal(t, "s2", sessions[1].ID)
+}
+
+func TestListSessions_EmptyItems(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items":    []interface{}{},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	sessions, err := client.ListSessions(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, sessions)
+}
+
+func TestListDisks_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "d1"},
+				},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	disks, err := client.ListDisks(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, disks, 1)
+	assert.Equal(t, "d1", disks[0].ID)
+}
+
+func TestListMessages_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "m1", "role": "user", "content": "hello"},
+					{"id": "m2", "role": "assistant", "content": "hi"},
+				},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	messages, err := client.ListMessages(context.Background(), "s1", nil)
+	require.NoError(t, err)
+	assert.Len(t, messages, 2)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "hello", messages[0].Content)
+}
+
+func TestListArtifacts_Response(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"artifacts": []map[string]interface{}{
+					{"id": "a1", "disk_id": "d1", "path": "/docs/readme.md"},
+					{"id": "a2", "disk_id": "d1", "path": "/docs/guide.md"},
+				},
+				"directories": []string{"images", "config"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	artifacts, err := client.ListArtifacts(context.Background(), "d1")
+	require.NoError(t, err)
+	assert.Len(t, artifacts, 2)
+	assert.Equal(t, "a1", artifacts[0].ID)
+	assert.Equal(t, "/docs/readme.md", artifacts[0].Path)
+}
+
+func TestListAgentSkills_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "sk1", "name": "my-skill"},
+				},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	skills, err := client.ListAgentSkills(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, skills, 1)
+	assert.Equal(t, "my-skill", skills[0].Name)
+}
+
+func TestListUsers_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "u1", "identifier": "alice@test.com"},
+				},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	users, err := client.ListUsers(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, "alice@test.com", users[0].Identifier)
+}
+
+func TestListLearningSpaces_PaginatedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"code": 200,
+			"data": map[string]interface{}{
+				"items": []map[string]string{
+					{"id": "ls1", "project_id": "p1"},
+				},
+				"has_more": false,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	spaces, err := client.ListLearningSpaces(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, spaces, 1)
+	assert.Equal(t, "ls1", spaces[0].ID)
+}
+
+func TestPing_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/ping", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"code": 200,
+			"msg":  "pong",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.Ping(context.Background())
+	require.NoError(t, err)
+}
+
+func TestPing_Failure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"code":  401,
+			"error": "invalid api key",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "bad-key", "jwt")
+	err := client.Ping(context.Background())
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok)
+	assert.Equal(t, 401, apiErr.StatusCode)
+}
+
+// --- Create/Get/Delete method tests ---
+
+func newEnvelopeServer(t *testing.T, wantMethod string, checkFn func(*http.Request), data interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if wantMethod != "" {
+			assert.Equal(t, wantMethod, r.Method)
+		}
+		if checkFn != nil {
+			checkFn(r)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "data": data})
+	}))
+}
+
+func TestCreateSession(t *testing.T) {
+	server := newEnvelopeServer(t, "POST", func(r *http.Request) {
+		var body CreateSessionRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "alice@test.com", body.User)
+	}, map[string]string{"id": "s-new", "project_id": "p1"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	session, err := client.CreateSession(context.Background(), &CreateSessionRequest{User: "alice@test.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "s-new", session.ID)
+}
+
+func TestGetSession_Success(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "s1", r.URL.Query().Get("id"))
+	}, map[string]interface{}{
+		"items": []map[string]string{{"id": "s1", "project_id": "p1"}},
+	})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	session, err := client.GetSession(context.Background(), "s1")
+	require.NoError(t, err)
+	assert.Equal(t, "s1", session.ID)
+}
+
+func TestGetSession_404WhenEmpty(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", nil, map[string]interface{}{
+		"items": []interface{}{},
+	})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	_, err := client.GetSession(context.Background(), "missing")
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok)
+	assert.Equal(t, 404, apiErr.StatusCode)
+}
+
+func TestDeleteSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/session/s1", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteSession(context.Background(), "s1")
+	require.NoError(t, err)
+}
+
+func TestStoreMessage(t *testing.T) {
+	server := newEnvelopeServer(t, "POST", func(r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/v1/session/s1/messages")
+		var body StoreMessageRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "user", body.Role)
+		assert.Equal(t, "hello", body.Content)
+	}, map[string]string{"id": "m1", "role": "user", "content": "hello"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	msg, err := client.StoreMessage(context.Background(), "s1", &StoreMessageRequest{Role: "user", Content: "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, "m1", msg.ID)
+}
+
+func TestCreateDisk(t *testing.T) {
+	server := newEnvelopeServer(t, "POST", func(r *http.Request) {
+		var body CreateDiskRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "alice", body.User)
+	}, map[string]string{"id": "d-new"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	disk, err := client.CreateDisk(context.Background(), &CreateDiskRequest{User: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, "d-new", disk.ID)
+}
+
+func TestGetDisk_Success(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "d1", r.URL.Query().Get("id"))
+	}, map[string]interface{}{
+		"items": []map[string]string{{"id": "d1"}},
+	})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	disk, err := client.GetDisk(context.Background(), "d1")
+	require.NoError(t, err)
+	assert.Equal(t, "d1", disk.ID)
+}
+
+func TestGetDisk_404WhenEmpty(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", nil, map[string]interface{}{
+		"items": []interface{}{},
+	})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	_, err := client.GetDisk(context.Background(), "missing")
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok)
+	assert.Equal(t, 404, apiErr.StatusCode)
+}
+
+func TestDeleteDisk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/disk/d1", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteDisk(context.Background(), "d1")
+	require.NoError(t, err)
+}
+
+func TestDeleteArtifact(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/docs/readme.md", r.URL.Query().Get("path"))
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteArtifact(context.Background(), "d1", "/docs/readme.md")
+	require.NoError(t, err)
+}
+
+func TestGetAgentSkill(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "/api/v1/agent_skills/sk1", r.URL.Path)
+	}, map[string]string{"id": "sk1", "name": "my-skill"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	skill, err := client.GetAgentSkill(context.Background(), "sk1")
+	require.NoError(t, err)
+	assert.Equal(t, "sk1", skill.ID)
+	assert.Equal(t, "my-skill", skill.Name)
+}
+
+func TestDeleteAgentSkill(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/agent_skills/sk1", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteAgentSkill(context.Background(), "sk1")
+	require.NoError(t, err)
+}
+
+func TestDeleteUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/user/alice@test.com", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteUser(context.Background(), "alice@test.com")
+	require.NoError(t, err)
+}
+
+func TestCreateLearningSpace(t *testing.T) {
+	server := newEnvelopeServer(t, "POST", func(r *http.Request) {
+		var body CreateLearningSpaceRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "alice", body.User)
+	}, map[string]string{"id": "ls-new"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	space, err := client.CreateLearningSpace(context.Background(), &CreateLearningSpaceRequest{User: "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, "ls-new", space.ID)
+}
+
+func TestGetLearningSpace(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "/api/v1/learning_spaces/ls1", r.URL.Path)
+	}, map[string]string{"id": "ls1"})
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	space, err := client.GetLearningSpace(context.Background(), "ls1")
+	require.NoError(t, err)
+	assert.Equal(t, "ls1", space.ID)
+}
+
+func TestDeleteLearningSpace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/learning_spaces/ls1", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.DeleteLearningSpace(context.Background(), "ls1")
+	require.NoError(t, err)
+}
+
+func TestLearnFromSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/learning_spaces/ls1/learn")
+		assert.Equal(t, "s1", r.URL.Query().Get("session_id"))
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	err := client.LearnFromSession(context.Background(), "ls1", "s1")
+	require.NoError(t, err)
+}
+
+// --- Admin methods ---
+
+func TestAdminCreateProject(t *testing.T) {
+	server := newEnvelopeServer(t, "POST", func(r *http.Request) {
+		assert.Equal(t, "/admin/v1/project", r.URL.Path)
+		var body CreateProjectRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "my-proj", body.Name)
+	}, map[string]string{"project_id": "p1", "secret_key": "sk-ac-xxx"})
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "jwt")
+	proj, err := client.AdminCreateProject(context.Background(), &CreateProjectRequest{Name: "my-proj"})
+	require.NoError(t, err)
+	assert.Equal(t, "p1", proj.ProjectID)
+	assert.Equal(t, "sk-ac-xxx", proj.SecretKey)
+}
+
+func TestAdminDeleteProject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/admin/v1/project/p1", r.URL.Path)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "jwt")
+	err := client.AdminDeleteProject(context.Background(), "p1")
+	require.NoError(t, err)
+}
+
+func TestAdminRotateKey(t *testing.T) {
+	server := newEnvelopeServer(t, "PUT", func(r *http.Request) {
+		assert.Equal(t, "/admin/v1/project/p1/secret_key", r.URL.Path)
+	}, map[string]string{"secret_key": "sk-ac-new"})
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "jwt")
+	resp, err := client.AdminRotateKey(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ac-new", resp.SecretKey)
+}
+
+func TestAdminGetProjectStats(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "/admin/v1/project/p1/statistics", r.URL.Path)
+	}, map[string]interface{}{"taskCount": 10, "skillCount": 3, "sessionCount": 5})
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "jwt")
+	stats, err := client.AdminGetProjectStats(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), stats.SessionCount)
+	assert.Equal(t, int64(10), stats.TaskCount)
+	assert.Equal(t, int64(3), stats.SkillCount)
+}
+
+func TestAdminGetProjectUsages(t *testing.T) {
+	server := newEnvelopeServer(t, "GET", func(r *http.Request) {
+		assert.Equal(t, "/admin/v1/project/p1/usages", r.URL.Path)
+	}, map[string]interface{}{"total": 100})
+	defer server.Close()
+
+	client := NewAdminClient(server.URL, "jwt")
+	usages, err := client.AdminGetProjectUsages(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.NotNil(t, usages)
+}
+
+// --- Put/Patch method tests ---
+
+func TestClientPut(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "data": map[string]string{"id": "x"}})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	var result map[string]string
+	err := client.Put(context.Background(), "/test", map[string]string{"a": "b"}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "x", result["id"])
+}
+
+func TestClientPatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "data": map[string]string{"id": "y"}})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	var result map[string]string
+	err := client.Patch(context.Background(), "/test", map[string]string{"a": "b"}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "y", result["id"])
+}
+
+// --- Error handling tests ---
+
+func TestErrorHandling_NonJSONBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	var result interface{}
+	err := client.Get(context.Background(), "/fail", &result)
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok)
+	assert.Equal(t, 500, apiErr.StatusCode)
+	assert.Equal(t, "Internal Server Error", apiErr.Message)
+}
+
+func TestErrorHandling_EnvelopeWithMsg(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"code": 403,
+			"msg":  "forbidden resource",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "key", "jwt")
+	var result interface{}
+	err := client.Get(context.Background(), "/forbidden", &result)
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok)
+	assert.Equal(t, 403, apiErr.StatusCode)
+	assert.Equal(t, "forbidden resource", apiErr.Message)
 }

--- a/src/client/acontext-cli/internal/api/public.go
+++ b/src/client/acontext-cli/internal/api/public.go
@@ -36,14 +36,21 @@ func buildQuery(params *ListParams) string {
 	return "?" + v.Encode()
 }
 
+// --- Ping (/api/v1/ping) ---
+
+// Ping checks connectivity to the API. Returns nil on success.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.Get(ctx, "/api/v1/ping", nil)
+}
+
 // --- Sessions (/api/v1/session) ---
 
 func (c *Client) ListSessions(ctx context.Context, params *ListParams) ([]Session, error) {
-	var sessions []Session
-	if err := c.Get(ctx, "/api/v1/session"+buildQuery(params), &sessions); err != nil {
+	var resp PaginatedResponse[Session]
+	if err := c.Get(ctx, "/api/v1/session"+buildQuery(params), &resp); err != nil {
 		return nil, err
 	}
-	return sessions, nil
+	return resp.Items, nil
 }
 
 func (c *Client) CreateSession(ctx context.Context, req *CreateSessionRequest) (*Session, error) {
@@ -55,15 +62,15 @@ func (c *Client) CreateSession(ctx context.Context, req *CreateSessionRequest) (
 }
 
 func (c *Client) GetSession(ctx context.Context, sessionID string) (*Session, error) {
-	var sessions []Session
+	var resp PaginatedResponse[Session]
 	v := url.Values{"id": {sessionID}}
-	if err := c.Get(ctx, "/api/v1/session?"+v.Encode(), &sessions); err != nil {
+	if err := c.Get(ctx, "/api/v1/session?"+v.Encode(), &resp); err != nil {
 		return nil, err
 	}
-	if len(sessions) == 0 {
+	if len(resp.Items) == 0 {
 		return nil, &APIError{StatusCode: 404, Message: "session not found"}
 	}
-	return &sessions[0], nil
+	return &resp.Items[0], nil
 }
 
 func (c *Client) DeleteSession(ctx context.Context, sessionID string) error {
@@ -73,11 +80,11 @@ func (c *Client) DeleteSession(ctx context.Context, sessionID string) error {
 // --- Messages (/api/v1/session/:id/messages) ---
 
 func (c *Client) ListMessages(ctx context.Context, sessionID string, params *ListParams) ([]Message, error) {
-	var messages []Message
-	if err := c.Get(ctx, "/api/v1/session/"+sessionID+"/messages"+buildQuery(params), &messages); err != nil {
+	var resp PaginatedResponse[Message]
+	if err := c.Get(ctx, "/api/v1/session/"+sessionID+"/messages"+buildQuery(params), &resp); err != nil {
 		return nil, err
 	}
-	return messages, nil
+	return resp.Items, nil
 }
 
 func (c *Client) StoreMessage(ctx context.Context, sessionID string, req *StoreMessageRequest) (*Message, error) {
@@ -91,11 +98,11 @@ func (c *Client) StoreMessage(ctx context.Context, sessionID string, req *StoreM
 // --- Disks (/api/v1/disk) ---
 
 func (c *Client) ListDisks(ctx context.Context, params *ListParams) ([]Disk, error) {
-	var disks []Disk
-	if err := c.Get(ctx, "/api/v1/disk"+buildQuery(params), &disks); err != nil {
+	var resp PaginatedResponse[Disk]
+	if err := c.Get(ctx, "/api/v1/disk"+buildQuery(params), &resp); err != nil {
 		return nil, err
 	}
-	return disks, nil
+	return resp.Items, nil
 }
 
 func (c *Client) CreateDisk(ctx context.Context, req *CreateDiskRequest) (*Disk, error) {
@@ -107,15 +114,15 @@ func (c *Client) CreateDisk(ctx context.Context, req *CreateDiskRequest) (*Disk,
 }
 
 func (c *Client) GetDisk(ctx context.Context, diskID string) (*Disk, error) {
-	var disks []Disk
+	var resp PaginatedResponse[Disk]
 	v := url.Values{"id": {diskID}}
-	if err := c.Get(ctx, "/api/v1/disk?"+v.Encode(), &disks); err != nil {
+	if err := c.Get(ctx, "/api/v1/disk?"+v.Encode(), &resp); err != nil {
 		return nil, err
 	}
-	if len(disks) == 0 {
+	if len(resp.Items) == 0 {
 		return nil, &APIError{StatusCode: 404, Message: "disk not found"}
 	}
-	return &disks[0], nil
+	return &resp.Items[0], nil
 }
 
 func (c *Client) DeleteDisk(ctx context.Context, diskID string) error {
@@ -125,11 +132,11 @@ func (c *Client) DeleteDisk(ctx context.Context, diskID string) error {
 // --- Artifacts (/api/v1/disk/:disk_id/artifact) ---
 
 func (c *Client) ListArtifacts(ctx context.Context, diskID string) ([]Artifact, error) {
-	var artifacts []Artifact
-	if err := c.Get(ctx, "/api/v1/disk/"+diskID+"/artifact/ls", &artifacts); err != nil {
+	var resp ListArtifactsResponse
+	if err := c.Get(ctx, "/api/v1/disk/"+diskID+"/artifact/ls", &resp); err != nil {
 		return nil, err
 	}
-	return artifacts, nil
+	return resp.Artifacts, nil
 }
 
 func (c *Client) UploadArtifact(ctx context.Context, diskID, filePath, destPath string) (*Artifact, error) {
@@ -206,11 +213,11 @@ func (c *Client) CreateAgentSkill(ctx context.Context, zipPath, user, meta strin
 }
 
 func (c *Client) ListAgentSkills(ctx context.Context, params *ListParams) ([]AgentSkill, error) {
-	var skills []AgentSkill
-	if err := c.Get(ctx, "/api/v1/agent_skills"+buildQuery(params), &skills); err != nil {
+	var resp PaginatedResponse[AgentSkill]
+	if err := c.Get(ctx, "/api/v1/agent_skills"+buildQuery(params), &resp); err != nil {
 		return nil, err
 	}
-	return skills, nil
+	return resp.Items, nil
 }
 
 func (c *Client) GetAgentSkill(ctx context.Context, skillID string) (*AgentSkill, error) {
@@ -228,15 +235,15 @@ func (c *Client) DeleteAgentSkill(ctx context.Context, skillID string) error {
 // --- Users (/api/v1/user) ---
 
 func (c *Client) ListUsers(ctx context.Context, params *ListParams) ([]User, error) {
-	var users []User
+	var resp PaginatedResponse[User]
 	q := ""
 	if params != nil && params.Limit > 0 {
 		q = fmt.Sprintf("?limit=%d", params.Limit)
 	}
-	if err := c.Get(ctx, "/api/v1/user/ls"+q, &users); err != nil {
+	if err := c.Get(ctx, "/api/v1/user/ls"+q, &resp); err != nil {
 		return nil, err
 	}
-	return users, nil
+	return resp.Items, nil
 }
 
 func (c *Client) DeleteUser(ctx context.Context, identifier string) error {
@@ -246,11 +253,11 @@ func (c *Client) DeleteUser(ctx context.Context, identifier string) error {
 // --- Learning Spaces (/api/v1/learning_spaces) ---
 
 func (c *Client) ListLearningSpaces(ctx context.Context, params *ListParams) ([]LearningSpace, error) {
-	var spaces []LearningSpace
-	if err := c.Get(ctx, "/api/v1/learning_spaces"+buildQuery(params), &spaces); err != nil {
+	var resp PaginatedResponse[LearningSpace]
+	if err := c.Get(ctx, "/api/v1/learning_spaces"+buildQuery(params), &resp); err != nil {
 		return nil, err
 	}
-	return spaces, nil
+	return resp.Items, nil
 }
 
 func (c *Client) CreateLearningSpace(ctx context.Context, req *CreateLearningSpaceRequest) (*LearningSpace, error) {

--- a/src/client/acontext-cli/internal/api/types.go
+++ b/src/client/acontext-cli/internal/api/types.go
@@ -130,25 +130,25 @@ type LearnRequest struct {
 
 // --- /admin/v1/project ---
 
-type ProjectInfo struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	OrgID     string `json:"organization_id"`
-	SecretKey string `json:"secret_key,omitempty"`
-	CreatedAt string `json:"created_at"`
+// CreateProjectResponse matches the admin server's CreateProjectOutput.
+type CreateProjectResponse struct {
+	ProjectID string `json:"project_id"`
+	SecretKey string `json:"secret_key"`
 }
 
 type CreateProjectRequest struct {
 	Name string `json:"name"`
 }
 
+// RotateKeyResponse matches the admin server's UpdateSecretKeyOutput.
+type RotateKeyResponse struct {
+	SecretKey string `json:"secret_key"`
+}
+
 type ProjectStats struct {
-	ProjectID    string `json:"project_id"`
-	SessionCount int    `json:"session_count"`
-	MessageCount int    `json:"message_count"`
-	DiskCount    int    `json:"disk_count"`
-	SkillCount   int    `json:"skill_count"`
-	UserCount    int    `json:"user_count"`
+	TaskCount    int64 `json:"taskCount"`
+	SkillCount   int64 `json:"skillCount"`
+	SessionCount int64 `json:"sessionCount"`
 }
 
 // --- Pagination ---
@@ -158,4 +158,17 @@ type ListParams struct {
 	Limit    int    `json:"limit,omitempty"`
 	Cursor   string `json:"cursor,omitempty"`
 	TimeDesc bool   `json:"time_desc,omitempty"`
+}
+
+// PaginatedResponse wraps list endpoints that return {items, next_cursor, has_more}.
+type PaginatedResponse[T any] struct {
+	Items      []T    `json:"items"`
+	NextCursor string `json:"next_cursor,omitempty"`
+	HasMore    bool   `json:"has_more"`
+}
+
+// ListArtifactsResponse wraps the artifact ls endpoint response.
+type ListArtifactsResponse struct {
+	Artifacts   []Artifact `json:"artifacts"`
+	Directories []string   `json:"directories"`
 }

--- a/src/client/acontext-cli/internal/auth/keystore_test.go
+++ b/src/client/acontext-cli/internal/auth/keystore_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadKeyStore_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	ks, err := LoadKeyStore()
+	require.NoError(t, err)
+	assert.NotNil(t, ks)
+	assert.Empty(t, ks.Keys)
+	assert.Empty(t, ks.DefaultProject)
+}
+
+func TestSaveAndLoadKeyStore_Roundtrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	ks := &KeyStore{
+		DefaultProject: "proj-1",
+		Keys: map[string]string{
+			"proj-1": "sk-ac-key1",
+			"proj-2": "sk-ac-key2",
+		},
+	}
+	err := SaveKeyStore(ks)
+	require.NoError(t, err)
+
+	loaded, err := LoadKeyStore()
+	require.NoError(t, err)
+	assert.Equal(t, "proj-1", loaded.DefaultProject)
+	assert.Equal(t, "sk-ac-key1", loaded.Keys["proj-1"])
+	assert.Equal(t, "sk-ac-key2", loaded.Keys["proj-2"])
+}
+
+func TestSetAndGetProjectKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	err := SetProjectKey("proj-1", "sk-ac-abc")
+	require.NoError(t, err)
+
+	key := GetProjectKey("proj-1")
+	assert.Equal(t, "sk-ac-abc", key)
+}
+
+func TestSetDefaultProject(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	err := SetDefaultProject("proj-1")
+	require.NoError(t, err)
+
+	ks, err := LoadKeyStore()
+	require.NoError(t, err)
+	assert.Equal(t, "proj-1", ks.DefaultProject)
+}
+
+func TestRemoveProjectKey_ClearsDefaultIfMatched(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	_ = SetProjectKey("proj-1", "sk-ac-abc")
+	_ = SetDefaultProject("proj-1")
+
+	err := RemoveProjectKey("proj-1")
+	require.NoError(t, err)
+
+	ks, err := LoadKeyStore()
+	require.NoError(t, err)
+	assert.Empty(t, ks.Keys["proj-1"])
+	assert.Empty(t, ks.DefaultProject)
+}
+
+func TestRemoveProjectKey_KeepsDefaultIfDifferent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	_ = SetProjectKey("proj-1", "sk-ac-abc")
+	_ = SetProjectKey("proj-2", "sk-ac-def")
+	_ = SetDefaultProject("proj-1")
+
+	err := RemoveProjectKey("proj-2")
+	require.NoError(t, err)
+
+	ks, err := LoadKeyStore()
+	require.NoError(t, err)
+	assert.Empty(t, ks.Keys["proj-2"])
+	assert.Equal(t, "proj-1", ks.DefaultProject)
+}
+
+func TestGetProjectKey_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	key := GetProjectKey("nonexistent")
+	assert.Equal(t, "", key)
+}
+
+func TestKeyStoreFilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	err := SetProjectKey("proj-1", "sk-ac-test")
+	require.NoError(t, err)
+
+	path := filepath.Join(tmpDir, ".acontext", credentialsFileName)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}

--- a/src/client/acontext-cli/internal/auth/refresh.go
+++ b/src/client/acontext-cli/internal/auth/refresh.go
@@ -60,6 +60,101 @@ func EnsureValidToken() (string, error) {
 	return af.AccessToken, nil
 }
 
+// getSupabaseUser calls Supabase GET /auth/v1/user to verify the JWT is valid.
+// Returns user info on success, error on 401 or other failures.
+func getSupabaseUser(jwt string) (*AuthUser, error) {
+	req, err := http.NewRequest("GET", SupabaseURL+"/auth/v1/user", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("apikey", SupabaseAnonKey)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read user response: %w", err)
+	}
+
+	if resp.StatusCode == 401 {
+		return nil, fmt.Errorf("token rejected by Supabase (401)")
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("supabase user check failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var user struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, fmt.Errorf("parse user response: %w", err)
+	}
+	return &AuthUser{ID: user.ID, Email: user.Email}, nil
+}
+
+// ValidateAndRefresh validates the access token with Supabase and refreshes if needed.
+// Unlike RefreshIfNeeded (which only checks local expiry), this verifies the token is
+// actually accepted by Supabase (catches revoked tokens, deleted users, etc.).
+func ValidateAndRefresh(af *AuthFile) (*AuthFile, error) {
+	if af == nil {
+		return nil, fmt.Errorf("no auth file")
+	}
+
+	// Step 1: refresh if near expiry
+	if af.ExpiresWithin(refreshThreshold) {
+		refreshed, err := RefreshIfNeeded(af)
+		if err != nil {
+			return nil, err
+		}
+		af = refreshed
+	}
+
+	// Step 2: validate with Supabase
+	user, err := getSupabaseUser(af.AccessToken)
+	if err == nil {
+		// Token is valid — update user info if changed
+		if user.ID != af.User.ID || user.Email != af.User.Email {
+			af.User.ID = user.ID
+			af.User.Email = user.Email
+			_ = Save(af)
+		}
+		return af, nil
+	}
+
+	// Step 3: token rejected — try refresh if we have a refresh token
+	if af.RefreshToken == "" {
+		return nil, fmt.Errorf("token invalid and no refresh token available — run 'acontext login' again")
+	}
+
+	newTokens, refreshErr := refreshToken(af.RefreshToken)
+	if refreshErr != nil {
+		return nil, fmt.Errorf("token invalid and refresh failed — run 'acontext login' again: %w", refreshErr)
+	}
+
+	af.AccessToken = newTokens.AccessToken
+	af.RefreshToken = newTokens.RefreshToken
+	af.ExpiresAt = time.Now().Unix() + int64(newTokens.ExpiresIn)
+
+	// Step 4: re-validate the refreshed token
+	user, err = getSupabaseUser(af.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("refreshed token still invalid — run 'acontext login' again: %w", err)
+	}
+
+	af.User.ID = user.ID
+	af.User.Email = user.Email
+	if err := Save(af); err != nil {
+		return nil, fmt.Errorf("save refreshed auth: %w", err)
+	}
+	return af, nil
+}
+
 func refreshToken(refreshTok string) (*tokenResponse, error) {
 	bodyBytes, err := json.Marshal(map[string]string{"refresh_token": refreshTok})
 	if err != nil {

--- a/src/client/acontext-cli/internal/auth/store.go
+++ b/src/client/acontext-cli/internal/auth/store.go
@@ -75,18 +75,25 @@ func Save(af *AuthFile) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-// Clear removes auth.json (logout).
+// Clear removes auth.json and credentials.json (logout).
 func Clear() error {
 	dir, err := getConfigDir()
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(dir, authFileName)
-	if err := os.Remove(path); os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
+
+	// Remove auth.json
+	authPath := filepath.Join(dir, authFileName)
+	if err := os.Remove(authPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("cannot remove auth file: %w", err)
 	}
+
+	// Remove credentials.json
+	credPath := filepath.Join(dir, credentialsFileName)
+	if err := os.Remove(credPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot remove credentials file: %w", err)
+	}
+
 	return nil
 }
 

--- a/src/client/acontext-cli/internal/auth/store_test.go
+++ b/src/client/acontext-cli/internal/auth/store_test.go
@@ -43,10 +43,21 @@ func TestAuthLoadSaveClear(t *testing.T) {
 	assert.Equal(t, "test-token", af2.AccessToken)
 	assert.Equal(t, "test@example.com", af2.User.Email)
 
+	// Save a credential key so we can verify Clear removes it
+	err = SetProjectKey("proj-1", "sk-ac-test")
+	require.NoError(t, err)
+	assert.Equal(t, "sk-ac-test", GetProjectKey("proj-1"))
+
 	// Clear
 	err = Clear()
 	require.NoError(t, err)
 	assert.False(t, IsLoggedIn())
+
+	// Verify credentials.json is also removed
+	assert.Equal(t, "", GetProjectKey("proj-1"))
+	ks, ksErr := LoadKeyStore()
+	require.NoError(t, ksErr)
+	assert.Empty(t, ks.Keys)
 
 	// Clear again (idempotent)
 	err = Clear()

--- a/src/client/acontext-cli/internal/output/table_test.go
+++ b/src/client/acontext-cli/internal/output/table_test.go
@@ -1,0 +1,37 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderJSON_ValidStruct(t *testing.T) {
+	data := struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}{Name: "Alice", Age: 30}
+
+	err := RenderJSON(data)
+	require.NoError(t, err)
+}
+
+func TestRenderJSON_UnmarshalableType(t *testing.T) {
+	ch := make(chan int)
+	err := RenderJSON(ch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal JSON")
+}
+
+func TestRenderTable_NoPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RenderTable(
+			[]string{"ID", "Name", "Status"},
+			[][]string{
+				{"1", "Project A", "active"},
+				{"2", "Project B", "inactive"},
+			},
+		)
+	})
+}

--- a/src/client/acontext-cli/internal/tui/confirm_test.go
+++ b/src/client/acontext-cli/internal/tui/confirm_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func updateConfirm(m ConfirmModel, msgs ...tea.Msg) ConfirmModel {
+	var model tea.Model = m
+	for _, msg := range msgs {
+		model, _ = model.Update(msg)
+	}
+	return model.(ConfirmModel)
+}
+
+func TestNewConfirm_DefaultValue(t *testing.T) {
+	m := NewConfirm("Continue?", true)
+	assert.True(t, m.value)
+	assert.True(t, m.defaultValue)
+	assert.False(t, m.done)
+	assert.False(t, m.quitting)
+}
+
+func TestConfirm_PressY(t *testing.T) {
+	m := NewConfirm("Continue?", false)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	assert.True(t, m.value)
+	assert.True(t, m.done)
+}
+
+func TestConfirm_PressN(t *testing.T) {
+	m := NewConfirm("Continue?", true)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	assert.False(t, m.value)
+	assert.True(t, m.done)
+}
+
+func TestConfirm_EnterUsesDefault(t *testing.T) {
+	m := NewConfirm("Continue?", true)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, m.value)
+	assert.True(t, m.done)
+
+	m2 := NewConfirm("Continue?", false)
+	m2 = updateConfirm(m2, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.False(t, m2.value)
+	assert.True(t, m2.done)
+}
+
+func TestConfirm_CtrlC(t *testing.T) {
+	m := NewConfirm("Continue?", true)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyCtrlC})
+	assert.True(t, m.quitting)
+	assert.True(t, m.Cancelled())
+}
+
+func TestConfirm_Tab(t *testing.T) {
+	m := NewConfirm("Continue?", true)
+	assert.True(t, m.value)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyTab})
+	assert.False(t, m.value)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyTab})
+	assert.True(t, m.value)
+}
+
+func TestConfirm_LeftRight(t *testing.T) {
+	m := NewConfirm("Continue?", false)
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyLeft})
+	assert.True(t, m.Value())
+	m = updateConfirm(m, tea.KeyMsg{Type: tea.KeyRight})
+	assert.False(t, m.Value())
+}

--- a/src/client/acontext-cli/internal/tui/input.go
+++ b/src/client/acontext-cli/internal/tui/input.go
@@ -92,12 +92,12 @@ func (m InputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			bytePos := runeOffset(m.value, m.cursorPos)
 			m.value = m.value[:bytePos]
 		default:
-			// Handle regular character input (supports multi-byte Unicode)
-			if utf8.RuneCountInString(msg.String()) == 1 {
-				char := msg.String()
+			// Handle regular character input and paste (supports multi-byte Unicode)
+			input := msg.String()
+			if inputLen := utf8.RuneCountInString(input); inputLen > 0 && msg.Type == tea.KeyRunes {
 				bytePos := runeOffset(m.value, m.cursorPos)
-				m.value = m.value[:bytePos] + char + m.value[bytePos:]
-				m.cursorPos++
+				m.value = m.value[:bytePos] + input + m.value[bytePos:]
+				m.cursorPos += inputLen
 			}
 		}
 	}

--- a/src/client/acontext-cli/internal/tui/input_test.go
+++ b/src/client/acontext-cli/internal/tui/input_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- runeOffset tests ---
+
+func TestRuneOffset_ASCII(t *testing.T) {
+	assert.Equal(t, 3, runeOffset("hello", 3))
+}
+
+func TestRuneOffset_MultiByte(t *testing.T) {
+	// "中文" is 6 bytes, 2 runes
+	assert.Equal(t, 3, runeOffset("中文", 1))
+	assert.Equal(t, 6, runeOffset("中文", 2))
+}
+
+func TestRuneOffset_Empty(t *testing.T) {
+	assert.Equal(t, 0, runeOffset("", 0))
+}
+
+func TestRuneOffset_BeyondLength(t *testing.T) {
+	// Should clamp to string length
+	assert.Equal(t, 5, runeOffset("hello", 10))
+}
+
+// --- InputModel tests ---
+
+func keyMsg(key string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+}
+
+func ctrlMsg(key string) tea.KeyMsg {
+	switch key {
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "backspace":
+		return tea.KeyMsg{Type: tea.KeyBackspace}
+	case "delete":
+		return tea.KeyMsg{Type: tea.KeyDelete}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	case "home":
+		return tea.KeyMsg{Type: tea.KeyHome}
+	case "end":
+		return tea.KeyMsg{Type: tea.KeyEnd}
+	case "ctrl+u":
+		return tea.KeyMsg{Type: tea.KeyCtrlU}
+	case "ctrl+k":
+		return tea.KeyMsg{Type: tea.KeyCtrlK}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+	}
+}
+
+func updateInput(m InputModel, msgs ...tea.Msg) InputModel {
+	var model tea.Model = m
+	for _, msg := range msgs {
+		model, _ = model.Update(msg)
+	}
+	return model.(InputModel)
+}
+
+func TestInputModel_TypeCharacters(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), keyMsg("c"))
+	assert.Equal(t, "abc", m.value)
+	assert.Equal(t, 3, m.cursorPos)
+}
+
+func TestInputModel_Backspace(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), ctrlMsg("backspace"))
+	assert.Equal(t, "a", m.value)
+	assert.Equal(t, 1, m.cursorPos)
+}
+
+func TestInputModel_Delete(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), ctrlMsg("home"), ctrlMsg("delete"))
+	assert.Equal(t, "b", m.value)
+	assert.Equal(t, 0, m.cursorPos)
+}
+
+func TestInputModel_LeftRight(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), ctrlMsg("left"))
+	assert.Equal(t, 1, m.cursorPos)
+	m = updateInput(m, ctrlMsg("right"))
+	assert.Equal(t, 2, m.cursorPos)
+}
+
+func TestInputModel_HomeEnd(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), keyMsg("c"))
+	m = updateInput(m, ctrlMsg("home"))
+	assert.Equal(t, 0, m.cursorPos)
+	m = updateInput(m, ctrlMsg("end"))
+	assert.Equal(t, 3, m.cursorPos)
+}
+
+func TestInputModel_CtrlU(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), keyMsg("c"), ctrlMsg("left"))
+	m = updateInput(m, ctrlMsg("ctrl+u"))
+	assert.Equal(t, "c", m.value)
+	assert.Equal(t, 0, m.cursorPos)
+}
+
+func TestInputModel_CtrlK(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("a"), keyMsg("b"), keyMsg("c"), ctrlMsg("home"), ctrlMsg("right"))
+	m = updateInput(m, ctrlMsg("ctrl+k"))
+	assert.Equal(t, "a", m.value)
+	assert.Equal(t, 1, m.cursorPos)
+}
+
+func TestInputModel_CtrlC(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, ctrlMsg("ctrl+c"))
+	assert.True(t, m.quitting)
+	assert.True(t, m.Cancelled())
+}
+
+func TestInputModel_Enter(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	m = updateInput(m, keyMsg("h"), keyMsg("i"), ctrlMsg("enter"))
+	assert.True(t, m.done)
+	assert.Equal(t, "hi", m.Value())
+}
+
+func TestInputModel_ValueReturnsDefault(t *testing.T) {
+	m := NewInput("Name:", "", "default-val")
+	// Clear the pre-filled default value
+	m.value = ""
+	assert.Equal(t, "default-val", m.Value())
+}
+
+func TestInputModel_PasteMultiRune(t *testing.T) {
+	m := NewInput("Name:", "", "")
+	// Simulate paste by sending a multi-rune KeyRunes message
+	paste := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hello")}
+	m = updateInput(m, paste)
+	assert.Equal(t, "hello", m.value)
+	assert.Equal(t, 5, m.cursorPos)
+}

--- a/src/client/acontext-cli/internal/tui/select_test.go
+++ b/src/client/acontext-cli/internal/tui/select_test.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+var testOptions = []SelectOption{
+	{Label: "Option A", Value: "a"},
+	{Label: "Option B", Value: "b"},
+	{Label: "Option C", Value: "c"},
+}
+
+func updateSelect(m SelectModel, msgs ...tea.Msg) SelectModel {
+	var model tea.Model = m
+	for _, msg := range msgs {
+		model, _ = model.Update(msg)
+	}
+	return model.(SelectModel)
+}
+
+func TestNewSelect_Defaults(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, -1, m.selected)
+	assert.False(t, m.done)
+	assert.False(t, m.quitting)
+}
+
+func TestSelect_DownArrow(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 1, m.cursor)
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.cursor)
+	// Should not go past last option
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.cursor)
+}
+
+func TestSelect_UpArrow(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	// At 0, up should stay at 0
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestSelect_EnterSelects(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyDown}) // cursor = 1
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, m.done)
+	assert.Equal(t, 1, m.Selected())
+	assert.Equal(t, "b", m.SelectedValue())
+}
+
+func TestSelect_CtrlC(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyCtrlC})
+	assert.True(t, m.quitting)
+	assert.Equal(t, -1, m.Selected())
+	assert.Equal(t, "", m.SelectedValue())
+}
+
+func TestSelect_SelectedValueAfterSelection(t *testing.T) {
+	m := NewSelect("Pick one:", testOptions)
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyDown}, tea.KeyMsg{Type: tea.KeyDown}) // cursor = 2
+	m = updateSelect(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, "c", m.SelectedValue())
+	assert.Equal(t, "Option C", testOptions[m.Selected()].Label)
+}


### PR DESCRIPTION
# Why we need this PR?

Improve CLI reliability and developer experience by fixing auth token validation, API response parsing, and adding a connectivity check command.

# Describe your solution

1. **ValidateAndRefresh**: Replace local-only expiry checks with Supabase token validation — catches revoked tokens, deleted users, etc.
2. **`dash ping` command**: New command to verify API connectivity for the current project, with helpful error messages on failure.
3. **Paginated responses**: Add generic `PaginatedResponse[T]` type to correctly parse `{items, next_cursor, has_more}` envelopes from all list endpoints.
4. **API type fixes**: `CreateProjectResponse` and `RotateKeyResponse` now match actual API output (was previously `ProjectInfo` with wrong fields).
5. **Logout cleanup**: `Clear()` now removes both `auth.json` and `credentials.json`.
6. **Remove env var fallbacks**: Drop `ACONTEXT_API_KEY`/`ACONTEXT_API_TOKEN` env var lookups — credentials.json is the single source of truth.
7. **TUI paste fix**: Input component now handles multi-rune paste events correctly.
8. **Rename `artifacts ls` → `artifacts list`**: Consistent with other subcommands.
9. **Test coverage**: Added comprehensive tests for all API client methods, TUI components, keystore, and output table.

# Implementation Tasks
- [x] Add `ValidateAndRefresh` in `auth/refresh.go` with Supabase user endpoint validation
- [x] Add `dash ping` command (`cmd/dash_ping.go`)
- [x] Add `PaginatedResponse[T]` generic type and update all list methods
- [x] Fix `CreateProjectResponse` / `RotateKeyResponse` types to match API
- [x] Update `Clear()` to remove credentials.json
- [x] Remove env var fallbacks from `dash.go`, `skill_upload.go`, `login.go`
- [x] Fix TUI input paste handling
- [x] Rename artifacts `ls` → `list`
- [x] Add `printSetupComplete()` helper for consistent post-setup messaging
- [x] Update SKILL.md documentation
- [x] Add unit tests for API client, TUI, keystore, and output

# Impact Areas
- [x] CLI Tool
- [x] Documentation

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)