### PR TITLE
feat(cli): add non-TTY mode support and fix project delete sync

### DIFF
--- a/landingpage/public/SKILL.md
+++ b/landingpage/public/SKILL.md
@@ -23,9 +23,13 @@ Acontext provides Agent Skills as a Memory Layer for production AI agents. It pr
 
 ### 1. Install Acontext CLI
 
-If Acontext CLI is already installed, check for updates first:
+If Acontext CLI is already installed, upgrade to the latest version:
 ```bash
-acontext upgrade
+# v0.1.13+ supports --yes flag for non-interactive upgrade
+acontext upgrade --yes
+
+# For older versions (≤ 0.1.12), re-run the installer instead:
+curl -fsSL https://install.acontext.io | sh
 ```
 
 If not installed, install it:

--- a/src/client/acontext-cli/cmd/create.go
+++ b/src/client/acontext-cli/cmd/create.go
@@ -14,7 +14,10 @@ import (
 )
 
 var (
-	templatePath string // Custom template path, e.g., "python/custom-template"
+	templatePath   string // Custom template path, e.g., "python/custom-template"
+	createLanguage string // Language selection for non-interactive mode
+	createTemplate string // Template key for non-interactive mode
+	createGitInit  bool   // Initialize git repo without prompting
 )
 
 var CreateCmd = &cobra.Command{
@@ -31,7 +34,10 @@ You will be guided through:
 
 Use --template-path to specify a custom template folder from:
   https://github.com/memodb-io/Acontext-Examples
-  
+
+For non-interactive (non-TTY) usage, provide --language and --template:
+  acontext create my-project --language python --template openai
+
 Example:
   acontext create my-project --template-path "python/custom-template"
 `,
@@ -41,6 +47,9 @@ Example:
 
 func init() {
 	CreateCmd.Flags().StringVarP(&templatePath, "template-path", "t", "", "Custom template folder path from Acontext-Examples repository (e.g., python/custom-template)")
+	CreateCmd.Flags().StringVarP(&createLanguage, "language", "l", "", "Programming language (e.g., python, typescript)")
+	CreateCmd.Flags().StringVar(&createTemplate, "template", "", "Template key (e.g., openai, langchain)")
+	CreateCmd.Flags().BoolVar(&createGitInit, "git-init", false, "Initialize a Git repository (skips interactive prompt)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -93,17 +102,52 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// 3. Select language
-		language, err := promptLanguage()
-		if err != nil {
-			return err
+		var language string
+		if createLanguage != "" {
+			language = createLanguage
+		} else if !tui.IsTTY() {
+			languages := config.GetLanguages()
+			return fmt.Errorf("use --language to specify a language in non-interactive mode\navailable languages: %s", strings.Join(languages, ", "))
+		} else {
+			var err error
+			language, err = promptLanguage()
+			if err != nil {
+				return err
+			}
 		}
 		fmt.Printf("%s Selected language: %s\n", tui.SuccessStyle.Render(tui.IconSuccess), tui.SelectedStyle.Render(language))
 		fmt.Println()
 
 		// 4. Load config and select template
-		templateKey, preset, err := promptTemplate(language)
-		if err != nil {
-			return err
+		var templateKey string
+		var preset *config.Preset
+		if createTemplate != "" {
+			templateKey = fmt.Sprintf("%s.%s", language, createTemplate)
+			preset = &config.Preset{
+				Name:     createTemplate,
+				Template: templateKey,
+			}
+		} else if !tui.IsTTY() {
+			presets, err := config.GetPresets(language)
+			if err != nil {
+				return fmt.Errorf("failed to get templates for %s: %w", language, err)
+			}
+			names := make([]string, len(presets))
+			for i, p := range presets {
+				parts := strings.Split(p.Template, ".")
+				if len(parts) == 2 {
+					names[i] = parts[1]
+				} else {
+					names[i] = p.Template
+				}
+			}
+			return fmt.Errorf("use --template to specify a template in non-interactive mode\navailable templates for %s: %s", language, strings.Join(names, ", "))
+		} else {
+			var err error
+			templateKey, preset, err = promptTemplate(language)
+			if err != nil {
+				return err
+			}
 		}
 		fmt.Printf("%s Selected template: %s\n", tui.SuccessStyle.Render(tui.IconSuccess), tui.SelectedStyle.Render(preset.Name))
 		fmt.Println()
@@ -154,10 +198,16 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	// 8. Ask whether to initialize Git
-	initGit, err := tui.RunConfirm("Would you like to initialize a Git repository?", true)
-	if err != nil {
-		// User cancelled, treat as no
-		initGit = false
+	var initGit bool
+	if cmd.Flags().Changed("git-init") || !tui.IsTTY() {
+		initGit = createGitInit
+	} else {
+		var err error
+		initGit, err = tui.RunConfirm("Would you like to initialize a Git repository?", true)
+		if err != nil {
+			// User cancelled, treat as no
+			initGit = false
+		}
 	}
 
 	if initGit {

--- a/src/client/acontext-cli/cmd/dash_open.go
+++ b/src/client/acontext-cli/cmd/dash_open.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/memodb-io/Acontext/acontext-cli/internal/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,12 @@ func init() {
 		Short: "Open the Acontext Dashboard in your browser",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := "https://dash.acontext.io"
+
+			if !tui.IsTTY() {
+				fmt.Println(url)
+				return nil
+			}
+
 			fmt.Printf("Opening %s ...\n", url)
 
 			var openCmd *exec.Cmd

--- a/src/client/acontext-cli/cmd/dash_projects.go
+++ b/src/client/acontext-cli/cmd/dash_projects.go
@@ -268,6 +268,10 @@ func init() {
 			if err := dashAdminClient.AdminDeleteProject(context.Background(), args[0]); err != nil {
 				return err
 			}
+			// Delete project record from Supabase (organization_projects)
+			if err := auth.UnlinkProjectFromOrg(dashAccessToken, args[0]); err != nil {
+				fmt.Printf("Warning: failed to remove project from dashboard: %v\n", err)
+			}
 			// Clean up local key
 			_ = auth.RemoveProjectKey(args[0])
 			fmt.Printf("Project deleted: %s\n", args[0])

--- a/src/client/acontext-cli/cmd/upgrade.go
+++ b/src/client/acontext-cli/cmd/upgrade.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var upgradeYes bool
+
 var UpgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade Acontext CLI to the latest version",
@@ -28,6 +30,10 @@ The upgrade process:
 Note: This command requires sudo privileges on most systems.
 `,
 	RunE: runUpgrade,
+}
+
+func init() {
+	UpgradeCmd.Flags().BoolVarP(&upgradeYes, "yes", "y", false, "Skip upgrade confirmation prompt")
 }
 
 // VersionKey is the context key for storing version
@@ -100,10 +106,15 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	// Ask for confirmation
-	proceed, err := tui.RunConfirm("Would you like to upgrade now?", true)
-	if err != nil || !proceed {
-		fmt.Printf("\n%s Upgrade cancelled\n", tui.IconSkip)
-		return nil
+	if !upgradeYes {
+		if !tui.IsTTY() {
+			return fmt.Errorf("use --yes to confirm upgrade in non-interactive mode")
+		}
+		proceed, err := tui.RunConfirm("Would you like to upgrade now?", true)
+		if err != nil || !proceed {
+			fmt.Printf("\n%s Upgrade cancelled\n", tui.IconSkip)
+			return nil
+		}
 	}
 
 	fmt.Println()

--- a/src/client/acontext-cli/internal/auth/supabase.go
+++ b/src/client/acontext-cli/internal/auth/supabase.go
@@ -111,6 +111,18 @@ func LinkProjectToOrg(jwt, orgID, projectName, projectID string) error {
 	return nil
 }
 
+// UnlinkProjectFromOrg deletes a project record from organization_projects in Supabase.
+func UnlinkProjectFromOrg(jwt, projectID string) error {
+	params := url.Values{
+		"project_id": {"eq." + projectID},
+	}
+	_, err := supabaseDelete("/rest/v1/organization_projects", params, jwt)
+	if err != nil {
+		return fmt.Errorf("unlink project from org: %w", err)
+	}
+	return nil
+}
+
 // ClaimCLISession calls the claim-cli-session Edge Function.
 // Returns nil, nil if no session found yet (pending).
 func ClaimCLISession(state string) (*AuthFile, error) {
@@ -243,6 +255,32 @@ func supabasePost(path string, payload interface{}, jwt string) ([]byte, error) 
 	}
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("supabase POST failed (%d): %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+func supabaseDelete(path string, params url.Values, jwt string) ([]byte, error) {
+	u := SupabaseURL + path + "?" + params.Encode()
+
+	req, err := http.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("apikey", SupabaseAnonKey)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("supabase DELETE failed (%d): %s", resp.StatusCode, string(body))
 	}
 	return body, nil
 }


### PR DESCRIPTION
# Why we need this PR?

CLI commands (`create`, `upgrade`, `dash open`) require interactive TTY prompts, making them unusable in non-interactive/agent environments. Additionally, `dash projects delete` only deletes from the API but not from Supabase, causing deleted projects to still appear on the Dashboard.

# Describe your solution

1. **Non-TTY mode for `create`**: Add `--language`, `--template`, `--git-init` flags. In non-TTY mode without required flags, list available options in the error message.
2. **Non-TTY mode for `upgrade`**: Add `--yes`/`-y` flag to skip confirmation, matching existing `dash * delete` patterns.
3. **Non-TTY mode for `dash open`**: Print URL only (no browser open attempt) when not a TTY.
4. **Fix `dash projects delete`**: Add `UnlinkProjectFromOrg()` to also delete the `organization_projects` record in Supabase, aligning with the Dashboard's two-step delete (`deleteProjects` + `deleteProject`).
5. **Update SKILL.md**: Note that `--yes` flag requires v0.1.13+, with fallback `curl` command for older versions.

# Implementation Tasks

- [x] `cmd/create.go` — add `--language`/`-l`, `--template`, `--git-init` flags with non-TTY error messages listing available options
- [x] `cmd/upgrade.go` — add `--yes`/`-y` flag, non-TTY guard matching existing `dash * delete` pattern
- [x] `cmd/dash_open.go` — TTY check: print URL only in non-TTY mode
- [x] `cmd/dash_projects.go` — call `auth.UnlinkProjectFromOrg()` after admin API delete
- [x] `internal/auth/supabase.go` — add `supabaseDelete()` helper and `UnlinkProjectFromOrg()` function
- [x] `landingpage/public/SKILL.md` — document version requirement for `--yes` flag

# Impact Areas

- [x] CLI Tool
- [x] Dashboard (alignment fix for project deletion)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] `go build ./...` passes successfully.
- [x] `go vet ./...` passes successfully.