### PR TITLE
chore: release claude-code plugin v0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,12 @@
 {
   "name": "memodb-io",
-  "owner": { "name": "memodb-io" },
+  "owner": {
+    "name": "memodb-io"
+  },
   "plugins": [
     {
       "name": "acontext",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "./src/packages/claude-code/plugin",
       "description": "Skill memory layer for Claude Code - auto-capture, learn, and reuse skills"
     }

--- a/.github/workflows/package-release-claude-code.yaml
+++ b/.github/workflows/package-release-claude-code.yaml
@@ -1,0 +1,166 @@
+name: Claude Code Plugin Release
+
+on:
+  push:
+    tags:
+      - 'package-claude-code/v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: src/packages/claude-code
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+
+      - name: Extract version from package.json
+        id: pkg_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Package version: $VERSION"
+
+      - name: Extract version from tag
+        id: tag_version
+        env:
+          GIT_REF: ${{ github.ref }}
+        run: |
+          if [[ "$GIT_REF" == refs/tags/* ]]; then
+            TAG_NAME=${GIT_REF#refs/tags/package-claude-code/v}
+            echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "Tag version: $TAG_NAME"
+          else
+            echo "version=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Verify tag matches package.json
+        if: steps.tag_version.outputs.version != ''
+        env:
+          PKG_VERSION: ${{ steps.pkg_version.outputs.version }}
+          TAG_VERSION: ${{ steps.tag_version.outputs.version }}
+        run: |
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: package.json version ($PKG_VERSION) does not match tag version ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version match: $PKG_VERSION"
+
+      - name: Verify plugin.json version
+        env:
+          PKG_VERSION: ${{ steps.pkg_version.outputs.version }}
+        run: |
+          PLUGIN_VERSION=$(node -p "require('./plugin/.claude-plugin/plugin.json').version")
+          if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "Error: plugin.json version ($PLUGIN_VERSION) does not match package.json ($PKG_VERSION)"
+            echo "Hint: run 'npm run release -- $PKG_VERSION' to sync all versions"
+            exit 1
+          fi
+          echo "plugin.json version: $PLUGIN_VERSION ✓"
+
+      - name: Verify marketplace.json version
+        env:
+          PKG_VERSION: ${{ steps.pkg_version.outputs.version }}
+        run: |
+          MKT_VERSION=$(node -p "require('../../../.claude-plugin/marketplace.json').plugins.find(p => p.name === 'acontext').version")
+          if [ "$PKG_VERSION" != "$MKT_VERSION" ]; then
+            echo "Error: marketplace.json version ($MKT_VERSION) does not match package.json ($PKG_VERSION)"
+            echo "Hint: run 'npm run release -- $PKG_VERSION' to sync all versions"
+            exit 1
+          fi
+          echo "marketplace.json version: $MKT_VERSION ✓"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Save committed bundle checksums
+        run: |
+          sha256sum plugin/scripts/mcp-server.cjs plugin/scripts/hook-handler.cjs > /tmp/committed-checksums.txt
+          echo "Committed checksums:"
+          cat /tmp/committed-checksums.txt
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify build output
+        run: |
+          node -e "
+            const fs = require('fs');
+            const files = ['plugin/scripts/mcp-server.cjs', 'plugin/scripts/hook-handler.cjs'];
+            for (const f of files) {
+              if (!fs.existsSync(f)) { console.error('Missing: ' + f); process.exit(1); }
+              const stat = fs.statSync(f);
+              if (stat.size < 1000) { console.error('Suspiciously small: ' + f + ' (' + stat.size + ' bytes)'); process.exit(1); }
+              console.log('OK: ' + f + ' (' + (stat.size / 1024).toFixed(0) + ' KB)');
+            }
+          "
+
+      - name: Verify bundles match committed artifacts
+        run: |
+          sha256sum plugin/scripts/mcp-server.cjs plugin/scripts/hook-handler.cjs > /tmp/rebuilt-checksums.txt
+          echo "Rebuilt checksums:"
+          cat /tmp/rebuilt-checksums.txt
+          if ! diff /tmp/committed-checksums.txt /tmp/rebuilt-checksums.txt; then
+            echo ""
+            echo "Error: Committed bundles do not match a clean rebuild."
+            echo "Hint: run 'npm run release -- X.Y.Z' to rebuild and commit the updated bundles."
+            exit 1
+          fi
+          echo "Bundles match ✓"
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: verify
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version from tag
+        id: version
+        env:
+          GIT_REF: ${{ github.ref }}
+        run: |
+          TAG_NAME=${GIT_REF#refs/tags/package-claude-code/v}
+          echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Generate Changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CHANGELOG_FILE: ${{ github.workspace }}-CHANGELOG.txt
+        run: |
+          cat > "$CHANGELOG_FILE" << EOF
+          # Claude Code Plugin v${VERSION}
+
+          ## Installation
+
+          \`\`\`bash
+          claude mcp add-from-marketplace acontext --publisher memodb-io
+          \`\`\`
+
+          ## Release Checklist
+          - [x] Version synced across package.json, plugin.json, marketplace.json
+          - [x] Tests passed
+          - [x] Plugin bundles built and verified
+          EOF
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          body_path: ${{ github.workspace }}-CHANGELOG.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,11 +55,22 @@ When releasing a new version, follow these steps in order:
    - Python SDK: update `version` in `src/client/acontext-py/pyproject.toml`
    - OpenClaw Plugin: update `"version"` in `src/packages/openclaw/package.json`, `version` in `src/packages/openclaw/index.ts` (the plugin object), **and** `expect(plugin.version)` in `src/packages/openclaw/tests/plugin.test.ts`
    - Sandbox Cloudflare: update `"version"` in `src/packages/sandbox-cloudflare/package.json`
+   - Claude Code Plugin: run `npm run release -- X.Y.Z` in `src/packages/claude-code/` — this updates `package.json`, `plugin/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`, then rebuilds the plugin bundles automatically. Full steps:
+     ```bash
+     cd src/packages/claude-code
+     npm run release -- 0.1.1                    # bump 3 version files + rebuild bundles
+     cd ../../..
+     git add -A && git commit -m "chore: release claude-code plugin v0.1.1"
+     git tag package-claude-code/v0.1.1
+     git push && git push --tags                  # triggers CI: version verify + GitHub Release
+     ```
+     CI (`package-release-claude-code.yaml`) verifies that all 3 version files match the tag, runs tests, rebuilds bundles and checks that the rebuilt output matches the committed artifacts (catches forgotten rebuilds), then creates a GitHub Release. It does **not** publish to a registry — the plugin is distributed via the repo itself.
 2. **Regenerate the lock file** so it stays in sync:
    - TypeScript SDK: run `npm install` in `src/client/acontext-ts/` (updates `package-lock.json`)
    - Python SDK: run `uv lock` in `src/client/acontext-py/` (updates `uv.lock`)
    - OpenClaw Plugin: run `npm install` in `src/packages/openclaw/` (updates `package-lock.json`)
    - Sandbox Cloudflare: no lock file needed (template is synced from `src/server/sandbox/cloudflare` via `prepublishOnly` script)
+   - Claude Code Plugin: no lock file needed (`npm run release` already rebuilds bundles)
 3. **Commit** the version bump + lock file changes.
 4. **Tag** the commit to trigger the CI/CD release pipeline. Each tag pattern maps to a specific workflow, publish target, and directory:
 
@@ -73,6 +84,7 @@ When releasing a new version, follow these steps in order:
 | CLI                | `cli/vX.Y.Z`                        | GitHub Releases (binaries)                  | `src/client/acontext-cli`         | `release-cli.yaml`                        |
 | OpenClaw Plugin    | `package-openclaw/vX.Y.Z`           | npm (`@acontext/openclaw`)                  | `src/packages/openclaw`           | `release-package-openclaw.yaml`           |
 | Sandbox Cloudflare | `package-sandbox-cloudflare/vX.Y.Z` | npm (`@acontext/create-sandbox-cloudflare`) | `src/packages/sandbox-cloudflare` | `release-package-sandbox-cloudflare.yaml` |
+| Claude Code Plugin | `package-claude-code/vX.Y.Z`        | Claude Plugin Marketplace                   | `src/packages/claude-code`        | `release-package-claude-code.yaml`        |
 | Helm Chart         | `chart/vX.Y.Z`                      | ghcr.io (OCI helm chart)                    | `charts/acontext`                 | `release-helm.yaml`                       |
 
 All workflows create a GitHub Release with changelog. Docker builds produce multi-platform images (`linux/amd64`, `linux/arm64`). npm/PyPI workflows skip publishing if the version already exists on the registry.

--- a/src/packages/claude-code/package.json
+++ b/src/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acontext/claude-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Acontext skill memory plugin for Claude Code — auto-capture, learn, and reuse skills",
   "license": "Apache-2.0",
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsx build.ts",
+    "release": "tsx release.ts",
     "clean": "rm -rf plugin/scripts/*.cjs",
     "test": "vitest run"
   },

--- a/src/packages/claude-code/plugin/.claude-plugin/plugin.json
+++ b/src/packages/claude-code/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "acontext",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Skill memory layer for Claude Code — auto-capture, learn, and reuse skills from Acontext",
   "author": {
     "name": "memodb-io"

--- a/src/packages/claude-code/plugin/scripts/hook-handler.cjs
+++ b/src/packages/claude-code/plugin/scripts/hook-handler.cjs
@@ -17956,7 +17956,7 @@ var require_skills = __commonJS({
     })();
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.SkillsAPI = void 0;
-    var fs3 = __importStar(require("fs/promises"));
+    var fs4 = __importStar(require("fs/promises"));
     var path5 = __importStar(require("path"));
     var uploads_1 = require_uploads();
     var utils_1 = require_utils();
@@ -18062,21 +18062,21 @@ var require_skills = __commonJS({
       async download(skillId, options) {
         const skill = await this.get(skillId);
         const dest = path5.resolve(options.path);
-        await fs3.mkdir(dest, { recursive: true });
+        await fs4.mkdir(dest, { recursive: true });
         const downloaded = [];
         for (const fi of skill.file_index) {
           const resp = await this.getFile({ skillId, filePath: fi.path });
           const fileDest = path5.join(dest, fi.path);
-          await fs3.mkdir(path5.dirname(fileDest), { recursive: true });
+          await fs4.mkdir(path5.dirname(fileDest), { recursive: true });
           if (resp.content) {
-            await fs3.writeFile(fileDest, resp.content.raw, "utf-8");
+            await fs4.writeFile(fileDest, resp.content.raw, "utf-8");
           } else if (resp.url) {
             const r = await fetch(resp.url);
             if (!r.ok) {
               throw new Error(`Failed to download ${fi.path}: ${r.status} ${r.statusText}`);
             }
             const buffer = Buffer.from(await r.arrayBuffer());
-            await fs3.writeFile(fileDest, buffer);
+            await fs4.writeFile(fileDest, buffer);
           }
           downloaded.push(fi.path);
         }
@@ -20849,19 +20849,49 @@ ${summary}
 };
 
 // src/config.ts
+var fs2 = __toESM(require("node:fs"));
 var os = __toESM(require("node:os"));
 var path2 = __toESM(require("node:path"));
+function getAcontextConfigDir() {
+  return process.env.ACONTEXT_CONFIG_DIR || path2.join(os.homedir(), ".acontext");
+}
+__name(getAcontextConfigDir, "getAcontextConfigDir");
+function loadApiKeyFromCredentials() {
+  try {
+    const filePath = path2.join(getAcontextConfigDir(), "credentials.json");
+    const data = JSON.parse(fs2.readFileSync(filePath, "utf-8"));
+    if (data.default_project && data.keys?.[data.default_project]) {
+      return data.keys[data.default_project];
+    }
+  } catch {
+  }
+  return void 0;
+}
+__name(loadApiKeyFromCredentials, "loadApiKeyFromCredentials");
+function loadUserIdFromAuth() {
+  try {
+    const filePath = path2.join(getAcontextConfigDir(), "auth.json");
+    const data = JSON.parse(fs2.readFileSync(filePath, "utf-8"));
+    if (data.user?.email) {
+      return data.user.email;
+    }
+  } catch {
+  }
+  return void 0;
+}
+__name(loadUserIdFromAuth, "loadUserIdFromAuth");
 function loadConfig() {
-  const apiKey = process.env.ACONTEXT_API_KEY?.trim();
+  const apiKey = loadApiKeyFromCredentials() || process.env.ACONTEXT_API_KEY?.trim();
   if (!apiKey) {
     throw new Error(
-      "ACONTEXT_API_KEY is required. Set it in your shell profile or Claude Code settings."
+      "ACONTEXT_API_KEY is required. Set it in your shell profile, or run 'acontext login' to configure ~/.acontext/credentials.json."
     );
   }
+  const userId = loadUserIdFromAuth() || process.env.ACONTEXT_USER_ID?.trim() || "default";
   return {
     apiKey,
     baseUrl: process.env.ACONTEXT_BASE_URL?.trim() || "https://api.acontext.app/api/v1",
-    userId: process.env.ACONTEXT_USER_ID?.trim() || "default",
+    userId,
     learningSpaceId: process.env.ACONTEXT_LEARNING_SPACE_ID?.trim() || void 0,
     skillsDir: process.env.ACONTEXT_SKILLS_DIR?.trim() || path2.join(os.homedir(), ".claude", "skills"),
     autoCapture: process.env.ACONTEXT_AUTO_CAPTURE !== "false",
@@ -20884,15 +20914,15 @@ function resolveDataDir() {
 __name(resolveDataDir, "resolveDataDir");
 
 // src/lock.ts
-var fs2 = __toESM(require("node:fs/promises"));
+var fs3 = __toESM(require("node:fs/promises"));
 var path3 = __toESM(require("node:path"));
 var LOCK_STALE_MS = 3e4;
 async function acquireLock(lockDir) {
   const MAX_RETRIES = 3;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      await fs2.mkdir(lockDir, { recursive: false });
-      await fs2.writeFile(
+      await fs3.mkdir(lockDir, { recursive: false });
+      await fs3.writeFile(
         path3.join(lockDir, "info"),
         JSON.stringify({ pid: process.pid, ts: Date.now() })
       ).catch(() => {
@@ -20902,17 +20932,17 @@ async function acquireLock(lockDir) {
       if (err?.code !== "EEXIST") throw err;
       let reclaimed = false;
       try {
-        const raw = await fs2.readFile(path3.join(lockDir, "info"), "utf-8");
+        const raw = await fs3.readFile(path3.join(lockDir, "info"), "utf-8");
         const { ts } = JSON.parse(raw);
         if (Date.now() - ts > LOCK_STALE_MS) {
-          await fs2.rm(lockDir, { recursive: true, force: true });
+          await fs3.rm(lockDir, { recursive: true, force: true });
           reclaimed = true;
         }
       } catch {
         try {
-          const stat2 = await fs2.stat(lockDir);
+          const stat2 = await fs3.stat(lockDir);
           if (Date.now() - stat2.mtimeMs > LOCK_STALE_MS) {
-            await fs2.rm(lockDir, { recursive: true, force: true });
+            await fs3.rm(lockDir, { recursive: true, force: true });
             reclaimed = true;
           }
         } catch {
@@ -20927,7 +20957,7 @@ async function acquireLock(lockDir) {
 }
 __name(acquireLock, "acquireLock");
 async function releaseLock(lockDir) {
-  await fs2.rm(lockDir, { recursive: true, force: true });
+  await fs3.rm(lockDir, { recursive: true, force: true });
 }
 __name(releaseLock, "releaseLock");
 

--- a/src/packages/claude-code/plugin/scripts/mcp-server.cjs
+++ b/src/packages/claude-code/plugin/scripts/mcp-server.cjs
@@ -7180,12 +7180,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs2, exportName) {
+    function addFormats(ajv, list, fs3, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs2[f]);
+        ajv.addFormat(f, fs3[f]);
     }
     __name(addFormats, "addFormats");
     module2.exports = exports2 = formatsPlugin;
@@ -25123,7 +25123,7 @@ var require_skills = __commonJS({
     })();
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.SkillsAPI = void 0;
-    var fs2 = __importStar(require("fs/promises"));
+    var fs3 = __importStar(require("fs/promises"));
     var path3 = __importStar(require("path"));
     var uploads_1 = require_uploads();
     var utils_1 = require_utils2();
@@ -25229,21 +25229,21 @@ var require_skills = __commonJS({
       async download(skillId, options) {
         const skill = await this.get(skillId);
         const dest = path3.resolve(options.path);
-        await fs2.mkdir(dest, { recursive: true });
+        await fs3.mkdir(dest, { recursive: true });
         const downloaded = [];
         for (const fi of skill.file_index) {
           const resp = await this.getFile({ skillId, filePath: fi.path });
           const fileDest = path3.join(dest, fi.path);
-          await fs2.mkdir(path3.dirname(fileDest), { recursive: true });
+          await fs3.mkdir(path3.dirname(fileDest), { recursive: true });
           if (resp.content) {
-            await fs2.writeFile(fileDest, resp.content.raw, "utf-8");
+            await fs3.writeFile(fileDest, resp.content.raw, "utf-8");
           } else if (resp.url) {
             const r = await fetch(resp.url);
             if (!r.ok) {
               throw new Error(`Failed to download ${fi.path}: ${r.status} ${r.statusText}`);
             }
             const buffer = Buffer.from(await r.arrayBuffer());
-            await fs2.writeFile(fileDest, buffer);
+            await fs3.writeFile(fileDest, buffer);
           }
           downloaded.push(fi.path);
         }
@@ -42623,19 +42623,49 @@ ${summary}
 };
 
 // src/config.ts
+var fs2 = __toESM(require("node:fs"));
 var os = __toESM(require("node:os"));
 var path2 = __toESM(require("node:path"));
+function getAcontextConfigDir() {
+  return process.env.ACONTEXT_CONFIG_DIR || path2.join(os.homedir(), ".acontext");
+}
+__name(getAcontextConfigDir, "getAcontextConfigDir");
+function loadApiKeyFromCredentials() {
+  try {
+    const filePath = path2.join(getAcontextConfigDir(), "credentials.json");
+    const data = JSON.parse(fs2.readFileSync(filePath, "utf-8"));
+    if (data.default_project && data.keys?.[data.default_project]) {
+      return data.keys[data.default_project];
+    }
+  } catch {
+  }
+  return void 0;
+}
+__name(loadApiKeyFromCredentials, "loadApiKeyFromCredentials");
+function loadUserIdFromAuth() {
+  try {
+    const filePath = path2.join(getAcontextConfigDir(), "auth.json");
+    const data = JSON.parse(fs2.readFileSync(filePath, "utf-8"));
+    if (data.user?.email) {
+      return data.user.email;
+    }
+  } catch {
+  }
+  return void 0;
+}
+__name(loadUserIdFromAuth, "loadUserIdFromAuth");
 function loadConfig() {
-  const apiKey = process.env.ACONTEXT_API_KEY?.trim();
+  const apiKey = loadApiKeyFromCredentials() || process.env.ACONTEXT_API_KEY?.trim();
   if (!apiKey) {
     throw new Error(
-      "ACONTEXT_API_KEY is required. Set it in your shell profile or Claude Code settings."
+      "ACONTEXT_API_KEY is required. Set it in your shell profile, or run 'acontext login' to configure ~/.acontext/credentials.json."
     );
   }
+  const userId = loadUserIdFromAuth() || process.env.ACONTEXT_USER_ID?.trim() || "default";
   return {
     apiKey,
     baseUrl: process.env.ACONTEXT_BASE_URL?.trim() || "https://api.acontext.app/api/v1",
-    userId: process.env.ACONTEXT_USER_ID?.trim() || "default",
+    userId,
     learningSpaceId: process.env.ACONTEXT_LEARNING_SPACE_ID?.trim() || void 0,
     skillsDir: process.env.ACONTEXT_SKILLS_DIR?.trim() || path2.join(os.homedir(), ".claude", "skills"),
     autoCapture: process.env.ACONTEXT_AUTO_CAPTURE !== "false",

--- a/src/packages/claude-code/release.ts
+++ b/src/packages/claude-code/release.ts
@@ -1,0 +1,68 @@
+/**
+ * Release script — bumps version in all plugin manifests, then rebuilds.
+ *
+ * Usage:  npm run release -- 0.2.0
+ *    or:  npx tsx release.ts 0.2.0
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
+const VERSION_FILES = [
+  // package.json  (this package)
+  path.join(rootDir, "package.json"),
+  // plugin.json   (plugin manifest)
+  path.join(rootDir, "plugin", ".claude-plugin", "plugin.json"),
+  // marketplace.json (marketplace registry)
+  path.join(rootDir, "..", "..", "..", ".claude-plugin", "marketplace.json"),
+];
+
+function updateVersion(filePath: string, version: string) {
+  const rel = path.relative(path.join(rootDir, "..","..",".."), filePath);
+  const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+
+  // marketplace.json has plugins[].version
+  if (Array.isArray(content.plugins)) {
+    for (const plugin of content.plugins) {
+      if (plugin.name === "acontext") {
+        plugin.version = version;
+      }
+    }
+  } else {
+    content.version = version;
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n");
+  console.log(`  ✓ ${rel}  →  ${version}`);
+}
+
+async function main() {
+  const version = process.argv[2];
+
+  if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
+    console.error("Usage: npm run release -- <semver>");
+    console.error("  e.g. npm run release -- 0.2.0");
+    process.exit(1);
+  }
+
+  console.log(`\nBumping version to ${version} ...\n`);
+
+  for (const file of VERSION_FILES) {
+    updateVersion(file, version);
+  }
+
+  console.log("\nRebuilding plugin ...\n");
+  // Safe: no user input in command string
+  execSync("npm run build", { cwd: rootDir, stdio: "inherit" });
+
+  console.log(`\nDone! Released v${version}\n`);
+}
+
+main().catch((err) => {
+  console.error("Release failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why
Release Claude Code plugin v0.1.1 with a proper release workflow and tooling.

## Solution
- Bump plugin version from 0.1.0 → 0.1.1 across all 3 manifest files
- Add `release.ts` script (`npm run release -- X.Y.Z`) to automate version bump + rebuild in one command
- Add `package-release-claude-code.yaml` CI workflow that:
  - Verifies tag matches all 3 version files (package.json, plugin.json, marketplace.json)
  - Runs tests and rebuilds bundles
  - Checks rebuilt bundles match committed artifacts (catches forgotten rebuilds)
  - Creates GitHub Release
- Update AGENTS.md with Claude Code Plugin release instructions

## Tasks
- [x] Add `release.ts` script
- [x] Add `release` npm script to package.json
- [x] Bump version to 0.1.1
- [x] Add CI release workflow
- [x] Update AGENTS.md

## Impact Areas
- `src/packages/claude-code/` — new release script, version bump, rebuilt bundles
- `.claude-plugin/marketplace.json` — version bump
- `.github/workflows/` — new release workflow
- `AGENTS.md` — release documentation

## Checklist
- [x] Version synced across package.json, plugin.json, marketplace.json
- [x] Plugin bundles rebuilt
- [x] AGENTS.md updated with release instructions
- [x] CI workflow follows existing patterns (pinned actions, env vars for GitHub context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)