### PR TITLE
feat(cli): remove --json flag and improve ping diagnostics

### DIFF
--- a/landingpage/public/SKILL.md
+++ b/landingpage/public/SKILL.md
@@ -13,9 +13,9 @@ keywords:
   - disk storage
 ---
 
-> **IMPORTANT — Save this skill for reuse:** After reading this document, save it to your local skill directory so it persists across sessions and you don't need to fetch it again.
-> - **Claude Code:** Create the directory `~/.claude/skills/acontext-installer/` and write this entire document to `~/.claude/skills/acontext-installer/SKILL.md`
-> - **OpenClaw:** Create the directory `~/.openclaw/skills/acontext-installer/` and write this entire document to `~/.openclaw/skills/acontext-installer/SKILL.md`
+> **IMPORTANT — Save this skill for reuse:** After reading this document, save it to your local skill directory so it persists across sessions and you don't need to fetch it again. If the skill already exists locally, overwrite it with this version to ensure you have the latest copy.
+> - **Claude Code:** Create the directory `~/.claude/skills/acontext-installer/` (if it doesn't exist) and write this entire document to `~/.claude/skills/acontext-installer/SKILL.md`, replacing any existing file.
+> - **OpenClaw:** Create the directory `~/.openclaw/skills/acontext-installer/` (if it doesn't exist) and write this entire document to `~/.openclaw/skills/acontext-installer/SKILL.md`, replacing any existing file.
 
 Acontext provides Agent Skills as a Memory Layer for production AI agents. It provides persistent sessions, disk-based file storage, learning spaces that distill conversations into reusable skills, and a CLI + API for managing everything.
 
@@ -97,7 +97,7 @@ openclaw gateway
 
 After you have logged in, you can manage Acontext projects via CLI:
 
-1. `acontext dash projects list --json` — list available projects
+1. `acontext dash projects list` — list available projects
 2. If user ask you to use a existing Acontext project, you should let the user to provide the api key. And then switch to this project `acontext dash projects select --project <project-id> --api-key <sk-ac-...>`.
 3. To create, ask for an org name and project name, then run: `acontext dash projects create --name <project-name> --org <org-id>`. This command returns the API key and auto-saves it as the default project (no need to run `select` afterwards).
 4. After select or create, verify the project is configured correctly:
@@ -205,6 +205,14 @@ Restart your shell or run `source ~/.bashrc` / `source ~/.zshrc`. The installer 
 - Ensure you have internet access and can reach `dash.acontext.io`
 - In non-TTY mode, make sure to run `acontext login --poll` after the user completes browser login
 - Check `~/.acontext/auth.json` for stored credentials
+
+### Switching API Key or Project
+
+If the user needs to change their API key or switch to a different project, use:
+```bash
+acontext dash projects select --project <project-id> --api-key <sk-ac-...>
+```
+This updates `~/.acontext/credentials.json` with the new key. Run `acontext dash ping` afterwards to verify connectivity.
 
 ### API returns 401 Unauthorized
 

--- a/src/client/acontext-cli/cmd/dash.go
+++ b/src/client/acontext-cli/cmd/dash.go
@@ -11,7 +11,6 @@ import (
 var (
 	dashAPIKey  string
 	dashProject string
-	dashJSON    bool
 	dashBaseURL string
 )
 
@@ -82,7 +81,6 @@ var DashCmd = &cobra.Command{
 func init() {
 	DashCmd.PersistentFlags().StringVar(&dashAPIKey, "api-key", "", "Project API key (overrides credentials.json)")
 	DashCmd.PersistentFlags().StringVar(&dashProject, "project", "", "Project ID to use")
-	DashCmd.PersistentFlags().BoolVar(&dashJSON, "json", false, "Output as JSON")
 	DashCmd.PersistentFlags().StringVar(&dashBaseURL, "base-url", "", "API base URL override")
 }
 

--- a/src/client/acontext-cli/cmd/dash_artifacts.go
+++ b/src/client/acontext-cli/cmd/dash_artifacts.go
@@ -24,9 +24,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(artifacts)
-			}
 			rows := make([][]string, len(artifacts))
 			for i, a := range artifacts {
 				rows[i] = []string{a.ID, a.Path, fmt.Sprintf("%d", a.Size), a.CreatedAt}
@@ -47,9 +44,6 @@ func init() {
 			artifact, err := c.UploadArtifact(context.Background(), args[0], args[1], destPath)
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(artifact)
 			}
 			fmt.Printf("Artifact uploaded: %s\n", artifact.ID)
 			fmt.Printf("Path: %s\n", artifact.Path)

--- a/src/client/acontext-cli/cmd/dash_disks.go
+++ b/src/client/acontext-cli/cmd/dash_disks.go
@@ -25,9 +25,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(disks)
-			}
 			rows := make([][]string, len(disks))
 			for i, d := range disks {
 				rows[i] = []string{d.ID, d.UserID, d.CreatedAt}
@@ -47,9 +44,6 @@ func init() {
 			disk, err := c.GetDisk(context.Background(), args[0])
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(disk)
 			}
 			fmt.Printf("ID:         %s\n", disk.ID)
 			fmt.Printf("User:       %s\n", disk.UserID)
@@ -73,9 +67,6 @@ func init() {
 			disk, err := c.CreateDisk(context.Background(), &api.CreateDiskRequest{User: user})
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(disk)
 			}
 			fmt.Printf("Disk created: %s\n", disk.ID)
 			return nil

--- a/src/client/acontext-cli/cmd/dash_messages.go
+++ b/src/client/acontext-cli/cmd/dash_messages.go
@@ -23,9 +23,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(messages)
-			}
 			rows := make([][]string, len(messages))
 			for i, m := range messages {
 				content := m.Content
@@ -54,9 +51,6 @@ func init() {
 			})
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(msg)
 			}
 			fmt.Printf("Message stored: %s\n", msg.ID)
 			return nil

--- a/src/client/acontext-cli/cmd/dash_ping.go
+++ b/src/client/acontext-cli/cmd/dash_ping.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/memodb-io/Acontext/acontext-cli/internal/output"
+	"github.com/memodb-io/Acontext/acontext-cli/internal/auth"
 	"github.com/memodb-io/Acontext/acontext-cli/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -14,19 +14,26 @@ func init() {
 		Short: "Check connectivity to the Acontext API",
 		Long:  "Verifies that the current project's API key is valid and the API is reachable.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// 1. Verify that we have a local key for the resolved project
+			if dashProject == "" {
+				return fmt.Errorf("no project selected\n\nTo fix this, run:\n  acontext dash projects select")
+			}
+
+			ks, err := auth.LoadKeyStore()
+			if err != nil {
+				return fmt.Errorf("failed to load credentials: %w", err)
+			}
+			if ks.Keys[dashProject] == "" {
+				return fmt.Errorf("no API key found in credentials.json for project %s\n\nTo fix this, run:\n  acontext dash projects select --project %s --api-key <sk-ac-...>\n\nThe API key can be found on the Acontext Dashboard:\n  https://dash.acontext.io", dashProject, dashProject)
+			}
+
+			// 2. Check API connectivity
 			client, err := requireClient()
 			if err != nil {
 				return err
 			}
 
 			if err := client.Ping(cmd.Context()); err != nil {
-				if dashJSON {
-					return output.RenderJSON(map[string]interface{}{
-						"status":  "error",
-						"project": dashProject,
-						"error":   err.Error(),
-					})
-				}
 				fmt.Printf("Ping failed for project %s: %v\n", dashProject, err)
 				fmt.Println()
 				fmt.Println("To fix this, re-select your project with a valid API key:")
@@ -35,13 +42,6 @@ func init() {
 				fmt.Println("The API key can be found on the Acontext Dashboard:")
 				fmt.Println("  https://dash.acontext.io")
 				return fmt.Errorf("ping failed")
-			}
-
-			if dashJSON {
-				return output.RenderJSON(map[string]interface{}{
-					"status":  "ok",
-					"project": dashProject,
-				})
 			}
 
 			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Project %s is reachable. Setup complete.", dashProject)))

--- a/src/client/acontext-cli/cmd/dash_projects.go
+++ b/src/client/acontext-cli/cmd/dash_projects.go
@@ -39,49 +39,33 @@ func init() {
 			// Load key store to show which projects have local keys
 			ks, _ := auth.LoadKeyStore()
 
-			var allProjects []auth.OrgProject
 			for _, org := range orgs {
 				projects, err := auth.ListProjects(dashAccessToken, org.ID)
 				if err != nil {
-					if !dashJSON {
-						fmt.Printf("Organization: %s (%s)\n", org.Name, org.ID)
-						fmt.Printf("  Error fetching projects: %v\n", err)
-					}
+					fmt.Printf("Organization: %s (%s)\n", org.Name, org.ID)
+					fmt.Printf("  Error fetching projects: %v\n", err)
 					continue
 				}
 
-				// Attach org id and name to each project
-				for i := range projects {
-					projects[i].OrgID = org.ID
-					projects[i].OrgName = org.Name
+				fmt.Printf("Organization: %s (%s)\n", org.Name, org.ID)
+				if len(projects) == 0 {
+					fmt.Println("  No projects")
+					continue
 				}
-				allProjects = append(allProjects, projects...)
-
-				if !dashJSON {
-					fmt.Printf("Organization: %s (%s)\n", org.Name, org.ID)
-					if len(projects) == 0 {
-						fmt.Println("  No projects")
-						continue
+				rows := make([][]string, len(projects))
+				for i, p := range projects {
+					hasKey := ""
+					if ks != nil && ks.Keys[p.ProjectID] != "" {
+						hasKey = "yes"
 					}
-					rows := make([][]string, len(projects))
-					for i, p := range projects {
-						hasKey := ""
-						if ks != nil && ks.Keys[p.ProjectID] != "" {
-							hasKey = "yes"
-						}
-						isDefault := ""
-						if ks != nil && ks.DefaultProject == p.ProjectID {
-							isDefault = "*"
-						}
-						rows[i] = []string{p.ProjectID, p.Name, hasKey, isDefault, p.CreatedAt}
+					isDefault := ""
+					if ks != nil && ks.DefaultProject == p.ProjectID {
+						isDefault = "*"
 					}
-					output.RenderTable([]string{"ID", "NAME", "HAS_KEY", "DEFAULT", "CREATED_AT"}, rows)
-					fmt.Println()
+					rows[i] = []string{p.ProjectID, p.Name, hasKey, isDefault, p.CreatedAt}
 				}
-			}
-
-			if dashJSON {
-				return output.RenderJSON(allProjects)
+				output.RenderTable([]string{"ID", "NAME", "HAS_KEY", "DEFAULT", "CREATED_AT"}, rows)
+				fmt.Println()
 			}
 			return nil
 		},
@@ -230,9 +214,6 @@ func init() {
 				return fmt.Errorf("link project to organization: %w", err)
 			}
 
-			if dashJSON {
-				return output.RenderJSON(project)
-			}
 			fmt.Printf("Project created: %s (%s)\n", name, project.ProjectID)
 
 			// Auto-save API key and set as default
@@ -287,9 +268,6 @@ func init() {
 			stats, err := dashAdminClient.AdminGetProjectStats(context.Background(), args[0])
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(stats)
 			}
 			fmt.Printf("Sessions:  %d\n", stats.SessionCount)
 			fmt.Printf("Tasks:     %d\n", stats.TaskCount)

--- a/src/client/acontext-cli/cmd/dash_sessions.go
+++ b/src/client/acontext-cli/cmd/dash_sessions.go
@@ -25,9 +25,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(sessions)
-			}
 			rows := make([][]string, len(sessions))
 			for i, s := range sessions {
 				rows[i] = []string{s.ID, s.UserID, s.CreatedAt}
@@ -47,9 +44,6 @@ func init() {
 			session, err := c.GetSession(context.Background(), args[0])
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(session)
 			}
 			fmt.Printf("ID:         %s\n", session.ID)
 			fmt.Printf("User:       %s\n", session.UserID)
@@ -74,9 +68,6 @@ func init() {
 			s, err := c.CreateSession(context.Background(), &api.CreateSessionRequest{User: user})
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(s)
 			}
 			fmt.Printf("Session created: %s\n", s.ID)
 			return nil

--- a/src/client/acontext-cli/cmd/dash_skills.go
+++ b/src/client/acontext-cli/cmd/dash_skills.go
@@ -30,9 +30,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(skills)
-			}
 			rows := make([][]string, len(skills))
 			for i, s := range skills {
 				desc := s.Description
@@ -56,9 +53,6 @@ func init() {
 			skill, err := c.GetAgentSkill(context.Background(), args[0])
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(skill)
 			}
 			fmt.Printf("ID:          %s\n", skill.ID)
 			fmt.Printf("Name:        %s\n", skill.Name)
@@ -112,9 +106,6 @@ func init() {
 			skill, err := c.CreateAgentSkill(context.Background(), zipPath, user, meta)
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(skill)
 			}
 			fmt.Printf("Skill created: %s\n", skill.ID)
 			fmt.Printf("Name: %s\n", skill.Name)

--- a/src/client/acontext-cli/cmd/dash_spaces.go
+++ b/src/client/acontext-cli/cmd/dash_spaces.go
@@ -25,9 +25,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(spaces)
-			}
 			rows := make([][]string, len(spaces))
 			for i, s := range spaces {
 				rows[i] = []string{s.ID, s.UserID, s.CreatedAt}
@@ -47,9 +44,6 @@ func init() {
 			space, err := c.GetLearningSpace(context.Background(), args[0])
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(space)
 			}
 			fmt.Printf("ID:         %s\n", space.ID)
 			fmt.Printf("User:       %s\n", space.UserID)
@@ -73,9 +67,6 @@ func init() {
 			space, err := c.CreateLearningSpace(context.Background(), &api.CreateLearningSpaceRequest{User: user})
 			if err != nil {
 				return err
-			}
-			if dashJSON {
-				return output.RenderJSON(space)
 			}
 			fmt.Printf("Learning space created: %s\n", space.ID)
 			return nil

--- a/src/client/acontext-cli/cmd/dash_users.go
+++ b/src/client/acontext-cli/cmd/dash_users.go
@@ -24,9 +24,6 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if dashJSON {
-				return output.RenderJSON(users)
-			}
 			rows := make([][]string, len(users))
 			for i, u := range users {
 				rows[i] = []string{u.ID, u.Identifier, u.CreatedAt}

--- a/src/client/acontext-cli/cmd/login.go
+++ b/src/client/acontext-cli/cmd/login.go
@@ -49,7 +49,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			fmt.Println("Credentials saved to ~/.acontext/auth.json")
 		}
 		fmt.Println()
-		fmt.Println("Next: set up a project. Run 'acontext dash projects list --json' to see available projects.")
+		fmt.Println("Next: set up a project. Run 'acontext dash projects list' to see available projects.")
 		return nil
 	}
 
@@ -178,7 +178,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		fmt.Println("This will retrieve the authentication tokens. Then proceed with project setup:")
 		fmt.Println()
-		fmt.Println("  1. Run 'acontext dash projects list --json' to see available projects.")
+		fmt.Println("  1. Run 'acontext dash projects list' to see available projects.")
 		fmt.Println("  2. If projects exist, show them to the user as a numbered table")
 		fmt.Println("     (# | org_name | name | project_id) and ask which one to use.")
 		fmt.Println("     Ask the user for the project's API key (found on https://dash.acontext.io), then run:")

--- a/src/client/acontext-cli/internal/output/table.go
+++ b/src/client/acontext-cli/internal/output/table.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -26,14 +25,4 @@ func RenderTable(headers []string, rows [][]string) {
 		_, _ = fmt.Fprintln(w, strings.Join(row, "\t"))
 	}
 	_ = w.Flush()
-}
-
-// RenderJSON prints v as indented JSON to stdout.
-func RenderJSON(v interface{}) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal JSON: %w", err)
-	}
-	fmt.Println(string(data))
-	return nil
 }

--- a/src/client/acontext-cli/internal/output/table_test.go
+++ b/src/client/acontext-cli/internal/output/table_test.go
@@ -4,25 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestRenderJSON_ValidStruct(t *testing.T) {
-	data := struct {
-		Name string `json:"name"`
-		Age  int    `json:"age"`
-	}{Name: "Alice", Age: 30}
-
-	err := RenderJSON(data)
-	require.NoError(t, err)
-}
-
-func TestRenderJSON_UnmarshalableType(t *testing.T) {
-	ch := make(chan int)
-	err := RenderJSON(ch)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "marshal JSON")
-}
 
 func TestRenderTable_NoPanic(t *testing.T) {
 	assert.NotPanics(t, func() {


### PR DESCRIPTION
## Why
The `--json` flag on dash commands was unused by agents and added unnecessary code paths. The `ping` command also lacked local credential checks, leading to confusing errors when no API key was configured.

## Solution
- Remove `--json` global flag and `RenderJSON` helper from all dash subcommands
- Improve `dash ping` to verify credentials locally before making API call, with actionable error messages guiding users to fix the issue
- Simplify `dash projects list` by removing the JSON accumulation path
- Update `SKILL.md` to remove `--json` references and add a "Switching API Key or Project" troubleshooting section

## Tasks
- [x] Remove `--json` flag from `dash.go`
- [x] Remove `RenderJSON` calls from all dash subcommands
- [x] Remove `RenderJSON` helper and its tests
- [x] Improve `dash ping` with local credential validation
- [x] Update `login.go` help text to remove `--json`
- [x] Update `SKILL.md` documentation

## Impact Areas
- `src/client/acontext-cli/cmd/` — all dash subcommands
- `src/client/acontext-cli/internal/output/` — removed `RenderJSON`
- `landingpage/public/SKILL.md` — documentation update

## Checklist
- [x] No breaking changes for existing table output users
- [x] `ping` now gives clear guidance when credentials are missing
- [x] Tests updated (removed `RenderJSON` tests)
- [x] SKILL.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)