### PR TITLE
fix(cli): record API key history when creating project via CLI

### DIFF
--- a/src/client/acontext-cli/cmd/dash_projects.go
+++ b/src/client/acontext-cli/cmd/dash_projects.go
@@ -220,6 +220,12 @@ func init() {
 			if project.SecretKey != "" {
 				if err := auth.SetProjectKey(project.ProjectID, project.SecretKey); err == nil {
 					_ = auth.SetDefaultProject(project.ProjectID)
+					// Record initial API key in history (best-effort, same as key rotation)
+					if dashAccessToken != "" && dashUserEmail != "" {
+						if rotErr := auth.RecordKeyRotation(dashAccessToken, project.ProjectID, dashUserEmail, project.SecretKey); rotErr != nil {
+							fmt.Printf("Warning: failed to record API key history: %v\n", rotErr)
+						}
+					}
 					fmt.Printf("Default project set to: %s\n", project.ProjectID)
 					printSetupComplete()
 				}


### PR DESCRIPTION
## Why

When creating a project via `acontext dash projects create`, the CLI saves the API key locally and sets it as default, but does **not** record it in the `project_secret_key_rotations` Supabase table. The Dashboard doesn't need this because it has an onboarding flow, but CLI-created projects should have their initial key tracked in history — consistent with how key rotation already works.

## Solution

Added a best-effort `RecordKeyRotation` call after saving the initial API key locally during project creation. This mirrors the existing key rotation flow:
- Masked key is recorded in Supabase `project_secret_key_rotations` table
- Non-blocking: if the Supabase insert fails, a warning is printed but project creation still succeeds

## Tasks

- [x] Add `RecordKeyRotation` call in `dash_projects.go` create command
- [x] Verify build passes

## Impact Areas

- `src/client/acontext-cli/cmd/dash_projects.go` — project create command

## Checklist

- [x] Code compiles (`go build ./...`)
- [x] Change is minimal and focused
- [x] Consistent with existing key rotation pattern


🤖 Generated with [Claude Code](https://claude.com/claude-code)