### PR TITLE
fix(openclaw): remove required apiKey from config schema

### DIFF
--- a/src/packages/openclaw/index.ts
+++ b/src/packages/openclaw/index.ts
@@ -167,7 +167,7 @@ export const configSchema = {
     }
     if (!resolvedApiKey) {
       throw new Error(
-        'apiKey is required (set config.apiKey, use "${ACONTEXT_API_KEY}", or run "acontext login")',
+        'ACONTEXT_API_KEY is required. Run "acontext login" to configure ~/.acontext/credentials.json, or set apiKey in plugin config.',
       );
     }
 

--- a/src/packages/openclaw/openclaw.plugin.json
+++ b/src/packages/openclaw/openclaw.plugin.json
@@ -8,7 +8,7 @@
       "label": "Acontext API Key",
       "sensitive": true,
       "placeholder": "sk-ac-...",
-      "help": "API key from dash.acontext.io (or use ${ACONTEXT_API_KEY})"
+      "help": "Auto-read from ~/.acontext/credentials.json after `acontext login`. Override with a literal key or ${ACONTEXT_API_KEY}."
     },
     "baseUrl": {
       "label": "API Base URL",
@@ -19,7 +19,7 @@
     "userId": {
       "label": "User ID",
       "placeholder": "default",
-      "help": "Scope sessions and skills per user"
+      "help": "Auto-read from ~/.acontext/auth.json after `acontext login`. Override to scope sessions and skills per user."
     },
     "learningSpaceId": {
       "label": "Learning Space ID",
@@ -82,6 +82,6 @@
         "default": 4
       }
     },
-    "required": ["apiKey"]
+    "required": []
   }
 }

--- a/src/packages/openclaw/tests/plugin.test.ts
+++ b/src/packages/openclaw/tests/plugin.test.ts
@@ -140,13 +140,13 @@ describe("configSchema.parse", () => {
 
   test("throws on missing apiKey when no credentials file", () => {
     expect(() => configSchema.parse({ userId: "bob" })).toThrow(
-      "apiKey is required",
+      "ACONTEXT_API_KEY is required",
     );
   });
 
   test("throws on empty apiKey when no credentials file", () => {
     expect(() => configSchema.parse({ apiKey: "" })).toThrow(
-      "apiKey is required",
+      "ACONTEXT_API_KEY is required",
     );
   });
 
@@ -198,7 +198,7 @@ describe("configSchema.parse", () => {
   test("throws on apiKey that resolves to whitespace only when no credentials file", () => {
     process.env.WHITESPACE_KEY = "   ";
     expect(() => configSchema.parse({ apiKey: "${WHITESPACE_KEY}" })).toThrow(
-      "apiKey is required",
+      "ACONTEXT_API_KEY is required",
     );
   });
 
@@ -206,7 +206,39 @@ describe("configSchema.parse", () => {
     process.env.EMPTY_KEY = "";
     // resolveEnvVars throws for empty env vars; falls through to credentials file
     expect(() => configSchema.parse({ apiKey: "${EMPTY_KEY}" })).toThrow(
-      "apiKey is required",
+      "ACONTEXT_API_KEY is required",
+    );
+  });
+
+  test("parses empty config when credentials.json exists", async () => {
+    const credPath = path.join(tmpConfigDir, "credentials.json");
+    await fs.writeFile(credPath, JSON.stringify({
+      default_project: "my-project",
+      keys: { "my-project": "sk-ac-from-creds" },
+    }));
+    const cfg = configSchema.parse({});
+    expect(cfg.apiKey).toBe("sk-ac-from-creds");
+    expect(cfg.userId).toBe("default");
+  });
+
+  test("parses empty config and reads userId from auth.json", async () => {
+    const credPath = path.join(tmpConfigDir, "credentials.json");
+    await fs.writeFile(credPath, JSON.stringify({
+      default_project: "my-project",
+      keys: { "my-project": "sk-ac-from-creds" },
+    }));
+    const authPath = path.join(tmpConfigDir, "auth.json");
+    await fs.writeFile(authPath, JSON.stringify({
+      user: { email: "alice@example.com" },
+    }));
+    const cfg = configSchema.parse({});
+    expect(cfg.apiKey).toBe("sk-ac-from-creds");
+    expect(cfg.userId).toBe("alice@example.com");
+  });
+
+  test("throws on empty config when no credentials file and no apiKey", () => {
+    expect(() => configSchema.parse({})).toThrow(
+      "ACONTEXT_API_KEY is required",
     );
   });
 });
@@ -1762,6 +1794,19 @@ describe("AcontextBridge", () => {
 // ============================================================================
 
 describe("plugin registration", () => {
+  const originalEnv = process.env;
+  let tmpConfigDir: string;
+
+  beforeEach(async () => {
+    tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reg-"));
+    process.env = { ...originalEnv, ACONTEXT_CONFIG_DIR: tmpConfigDir };
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await fs.rm(tmpConfigDir, { recursive: true, force: true }).catch(() => {});
+  });
+
   function createMockApi(pluginConfig: unknown) {
     const hooks: Record<string, Function[]> = {};
     const tools: Array<{ name: string; execute: Function }> = [];


### PR DESCRIPTION

# Why we need this PR?

The SKILL.md documents that both plugins (claude-code and openclaw) auto-read API key and user from `~/.acontext/credentials.json` and `~/.acontext/auth.json` after `acontext login`. Users should be able to use an empty config `config: {}`. However, `openclaw.plugin.json` still declares `"required": ["apiKey"]`, which forces users to provide an apiKey in config — contradicting the documented behavior and the claude-code plugin.

# Describe your solution

Align openclaw's config schema with claude-code: credentials come from `~/.acontext/` by default, config fields are optional overrides only.

- **apiKey**: `~/.acontext/credentials.json` → plugin config/env → error
- **userId**: `~/.acontext/auth.json` → plugin config → `"default"`

# Implementation Tasks

- [x] Remove `apiKey` from `required` in `openclaw.plugin.json`
- [x] Update `uiHints.apiKey.help` and `uiHints.userId.help` to clarify auto-read from `~/.acontext/`
- [x] Update error message in `configSchema.parse()` to mention `acontext login` first
- [x] Add tests for empty config `{}` with credentials/auth files
- [x] Fix test isolation for `plugin registration` describe block

# Impact Areas

- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: OpenClaw Plugin (`src/packages/openclaw/`)

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)