### PR TITLE
fix(openclaw): normalize pi-agent-core messages to OpenAI format before storing

### DIFF
--- a/src/packages/openclaw/index.ts
+++ b/src/packages/openclaw/index.ts
@@ -272,11 +272,10 @@ export async function atomicWriteFile(filePath: string, data: string): Promise<v
 type ContentBlock = {
   type: string;
   text?: string;
+  id?: string;
   name?: string;
-  toolCallId?: string;
-  toolName?: string;
+  arguments?: unknown;
   input?: unknown;
-  content?: unknown;
   [key: string]: unknown;
 };
 
@@ -353,16 +352,20 @@ function normalizeAssistantMessage(msg: AgentMessage): OpenAIMessage | null {
   for (const block of msg.content as ContentBlock[]) {
     if (block.type === "text" && block.text) {
       textParts.push(block.text);
-    } else if (block.type === "toolCall" || block.type === "tool_use") {
+    } else if (block.type === "toolCall" || block.type === "toolUse" || block.type === "tool_use" || block.type === "functionCall") {
+      const callId = (block.id ?? "") as string;
+      const fnName = (block.name ?? "") as string;
+      if (!callId || !fnName) continue;
+      const args = block.arguments ?? block.input;
       toolCalls.push({
-        id: (block.toolCallId ?? block.id ?? "") as string,
+        id: callId,
         type: "function",
         function: {
-          name: (block.toolName ?? block.name ?? "") as string,
+          name: fnName,
           arguments:
-            typeof block.input === "string"
-              ? block.input
-              : JSON.stringify(block.input ?? {}),
+            typeof args === "string"
+              ? args
+              : JSON.stringify(args ?? {}),
         },
       });
     }
@@ -379,13 +382,13 @@ function normalizeAssistantMessage(msg: AgentMessage): OpenAIMessage | null {
 }
 
 function normalizeToolResultMessage(msg: AgentMessage): OpenAIMessage | null {
-  const toolCallId = (msg as Record<string, unknown>).toolCallId as
-    | string
-    | undefined;
+  const raw = msg as Record<string, unknown>;
+  const toolCallId = (raw.toolCallId ?? raw.toolUseId) as string | undefined;
+  if (!toolCallId) return null;
   const content = extractTextContent(msg.content);
   return {
     role: "tool",
-    tool_call_id: toolCallId ?? "",
+    tool_call_id: toolCallId,
     content: content ?? "",
   };
 }
@@ -1393,7 +1396,7 @@ const acontextPlugin = {
     // Auto-capture + auto-learn: store messages and trigger learning
     if (cfg.autoCapture) {
       api.on("agent_end", async (event, ctx) => {
-        if (!event.success || !event.messages || event.messages.length === 0) {
+        if (!event.messages || event.messages.length === 0) {
           return;
         }
 

--- a/src/packages/openclaw/tests/plugin.test.ts
+++ b/src/packages/openclaw/tests/plugin.test.ts
@@ -2250,9 +2250,9 @@ describe("normalizeMessages", () => {
           { type: "text", text: "Let me check that." },
           {
             type: "toolCall",
-            toolCallId: "call_123",
-            toolName: "readFile",
-            input: { path: "/tmp/foo" },
+            id: "call_123",
+            name: "readFile",
+            arguments: { path: "/tmp/foo" },
           },
         ],
         model: "some-model",
@@ -2305,9 +2305,9 @@ describe("normalizeMessages", () => {
         content: [
           {
             type: "toolCall",
-            toolCallId: "call_456",
-            toolName: "bash",
-            input: { command: "ls" },
+            id: "call_456",
+            name: "bash",
+            arguments: { command: "ls" },
           },
         ],
       },
@@ -2399,9 +2399,9 @@ describe("normalizeMessages", () => {
           { type: "text", text: "I'll check." },
           {
             type: "toolCall",
-            toolCallId: "call_1",
-            toolName: "bash",
-            input: { command: "ls /tmp" },
+            id: "call_1",
+            name: "bash",
+            arguments: { command: "ls /tmp" },
           },
         ],
         model: "claude-3",
@@ -2494,5 +2494,102 @@ describe("normalizeMessages", () => {
       { role: "user", content: "hello" },
     ]);
     expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  test("toolResult with toolUseId fallback → converted", () => {
+    const result = normalizeMessages([
+      {
+        role: "toolResult",
+        toolUseId: "toolu_abc",
+        content: [{ type: "text", text: "result" }],
+      },
+    ]);
+    expect(result).toEqual([
+      { role: "tool", tool_call_id: "toolu_abc", content: "result" },
+    ]);
+  });
+
+  test("toolResult without toolCallId or toolUseId → skipped", () => {
+    const result = normalizeMessages([
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "orphan result" }],
+      },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  test("toolCall with string arguments → preserved as-is", () => {
+    const result = normalizeMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_str",
+            name: "exec",
+            arguments: '{"raw":"json"}',
+          },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_str",
+            type: "function",
+            function: { name: "exec", arguments: '{"raw":"json"}' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("toolCall with missing id or name → skipped", () => {
+    const result = normalizeMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "", name: "bash", arguments: {} },
+          { type: "toolCall", id: "call_1", name: "", arguments: {} },
+          { type: "text", text: "still here" },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      { role: "assistant", content: "still here" },
+    ]);
+  });
+
+  test("functionCall block type → converted", () => {
+    const result = normalizeMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "functionCall",
+            id: "fc_1",
+            name: "search",
+            arguments: { query: "test" },
+          },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "fc_1",
+            type: "function",
+            function: { name: "search", arguments: JSON.stringify({ query: "test" }) },
+          },
+        ],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
# Why we need this PR?

OpenClaw's `agent_end` hook passes pi-agent-core's internal `AgentMessage[]` to the plugin, which was stored as-is with `format: "openai"`. This caused:

1. Assistant messages with `content: undefined` → stored as empty `{ "role": "assistant" }`
2. `role: "toolResult"` is not a standard OpenAI role
3. Content blocks use `{type: "toolCall"}` instead of OpenAI's `tool_calls`
4. Extra fields (`stopReason`, `api`, `model`, `usage`, `timestamp`) pollute stored data
5. Thinking blocks leak into stored messages

# Describe your solution

Add a `normalizeMessages()` function that converts pi-agent-core `AgentMessage[]` to standard OpenAI Chat Completions format before storage:

- `user` messages: extract text from string or array content blocks
- `assistant` messages: text → `content`, `toolCall`/`tool_use` blocks → `tool_calls`, skip thinking blocks, drop empty messages
- `toolResult` → `{ role: "tool", tool_call_id, content }`
- Extra fields (`api`, `model`, `usage`, `timestamp`, etc.) are discarded
- Unknown roles and empty messages are skipped

# Implementation Tasks

- [x] Add `normalizeMessages()` function with helpers in `index.ts`
- [x] Wire `normalizeMessages()` into `agent_end` handler before `storeMessages()`
- [x] Add 13 test cases covering all conversion rules and edge cases

# Impact Areas

- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: OpenClaw Plugin

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.