### PR TITLE
chore: remove internal path references and simplify CLI output

### DIFF
--- a/landingpage/public/SKILL.md
+++ b/landingpage/public/SKILL.md
@@ -53,7 +53,7 @@ acontext login
 
 ### 3. Add Acontext to Your Agent
 
-Both plugins automatically read your API key and user email from `~/.acontext/credentials.json` and `~/.acontext/auth.json` (written by `acontext login`). No manual configuration is needed after login.
+Both plugins automatically read your API key and user email after `acontext login`. No manual configuration is needed.
 
 #### Option A: Claude Code Plugin
 
@@ -101,7 +101,6 @@ After you have logged in, you can manage Acontext projects via CLI:
 2. If user ask you to use a existing Acontext project, you should let the user to provide the api key. And then switch to this project `acontext dash projects select --project <project-id> --api-key <sk-ac-...>`.
 3. To create, ask for an org name and project name, then run: `acontext dash projects create --name <project-name> --org <org-id>`. This command returns the API key and auto-saves it as the default project (no need to run `select` afterwards).
 4. After select or create, verify the project is configured correctly:
-   - Check that `~/.acontext/credentials.json` contains the project key.
    - Run `acontext dash ping` to verify API connectivity. A successful response confirms the project is reachable.
 
 ## CLI Commands Reference
@@ -141,7 +140,7 @@ The directory must contain a `SKILL.md` with name and description in YAML front-
 
 ## Claude Code Plugin Configuration
 
-After `acontext login`, the plugin works automatically — API key and user are read from `~/.acontext/`. The following env vars can override defaults if needed:
+After `acontext login`, the plugin works automatically. The following env vars can override defaults if needed:
 
 | Env Var                        | Default                           | Description                            |
 | ------------------------------ | --------------------------------- | -------------------------------------- |
@@ -166,7 +165,7 @@ After `acontext login`, the plugin works automatically — API key and user are 
 
 ## OpenClaw Plugin Configuration
 
-After `acontext login`, the plugin works automatically — API key and user are read from `~/.acontext/`. Optional overrides in `openclaw.json` config:
+After `acontext login`, the plugin works automatically. Optional overrides in `openclaw.json` config:
 
 | Key                | Type      | Default                           | Description                              |
 | ------------------ | --------- | --------------------------------- | ---------------------------------------- |
@@ -198,13 +197,13 @@ After `acontext login`, the plugin works automatically — API key and user are 
 
 ### "command not found: acontext"
 
-Restart your shell or run `source ~/.bashrc` / `source ~/.zshrc`. The installer adds `~/.acontext/bin` to your PATH.
+Restart your shell or run `source ~/.bashrc` / `source ~/.zshrc`.
 
 ### Login fails or times out
 
 - Ensure you have internet access and can reach `dash.acontext.io`
 - In non-TTY mode, make sure to run `acontext login --poll` after the user completes browser login
-- Check `~/.acontext/auth.json` for stored credentials
+- Check stored credentials with `acontext whoami`
 
 ### Switching API Key or Project
 
@@ -212,7 +211,7 @@ If the user needs to change their API key or switch to a different project, use:
 ```bash
 acontext dash projects select --project <project-id> --api-key <sk-ac-...>
 ```
-This updates `~/.acontext/credentials.json` with the new key. Run `acontext dash ping` afterwards to verify connectivity.
+Run `acontext dash ping` afterwards to verify connectivity.
 
 ### API returns 401 Unauthorized
 
@@ -224,7 +223,6 @@ This updates `~/.acontext/credentials.json` with the new key. Run `acontext dash
 ### Claude Code plugin not working
 
 - Run `acontext whoami` to verify you are logged in
-- Check that `~/.acontext/credentials.json` exists and has a default project
 - Check Claude Code logs for `[info] acontext:` or `[warn] acontext:` messages
 - Verify the plugin is installed: `/plugin list`
 - Skills should appear in `~/.claude/skills/` after the first session

--- a/src/client/acontext-cli/README.md
+++ b/src/client/acontext-cli/README.md
@@ -1,135 +1,93 @@
 # Acontext CLI
 
-A lightweight command-line tool for quickly creating Acontext projects with templates and managing local development environments.
-
-## Features
-
-- 🚀 **Quick Setup**: Create projects in seconds with interactive templates
-- 🌐 **Multi-Language**: Support for Python and TypeScript
-- 🖥️ **Split-Screen TUI**: Run sandbox and Docker services together with real-time logs
-- 📦 **Package Manager Detection**: Auto-detect pnpm, npm, yarn, or bun
-- 🔧 **Auto Git**: Automatic Git repository initialization
-- 🔄 **Auto Update**: Automatic version checking and one-command upgrade
-- 🎯 **Simple**: Minimal configuration, maximum productivity
+A command-line tool for managing Acontext projects, authentication, and local development environments.
 
 ## Installation
 
-### User Installation (No sudo required - Recommended)
-
-By default, the CLI installs to `~/.acontext/bin` and automatically updates your shell profile (`.bashrc`, `.zshrc`, etc.):
+### User Installation (Recommended)
 
 ```bash
-# Install script (Linux, macOS, WSL)
 curl -fsSL https://install.acontext.io | sh
 ```
 
 After installation, restart your shell or run `source ~/.bashrc` (or `~/.zshrc` for zsh).
 
-### System-wide Installation (Requires sudo)
-
-For system-wide installation to `/usr/local/bin`:
+### System-wide Installation
 
 ```bash
 curl -fsSL https://install.acontext.io | sh -s -- --system
 ```
 
-## Usage
+## Quick Start
 
-### Create a New Project
+```bash
+# 1. Log in
+acontext login
+
+# 2. Set up a project (interactive selection after login)
+acontext dash projects list
+acontext dash projects select --project <id> --api-key <sk-ac-...>
+
+# 3. Verify connectivity
+acontext dash ping
+```
+
+## Command Reference
+
+### Authentication
+
+| Command | Description |
+|---------|-------------|
+| `acontext login` | Log in via browser OAuth |
+| `acontext login --poll` | Complete a pending non-interactive login |
+| `acontext logout` | Log out and clear credentials |
+| `acontext whoami` | Show the currently logged-in user |
+
+### Project Management
+
+| Command | Description |
+|---------|-------------|
+| `acontext dash projects list` | List organizations and projects |
+| `acontext dash projects select` | Select a default project (interactive or `--project <id>`) |
+| `acontext dash projects create --name <name>` | Create a new project |
+| `acontext dash projects delete <id>` | Delete a project |
+| `acontext dash projects stats <id>` | Show project statistics |
+| `acontext dash ping` | Verify API connectivity |
+| `acontext dash open` | Open the Dashboard in browser |
+
+### Skills
+
+| Command | Description |
+|---------|-------------|
+| `acontext skill upload <directory>` | Upload a local skill directory to Acontext |
+
+### Project Scaffolding
 
 ```bash
 # Interactive mode
 acontext create
 
-# Create with project name
-acontext create my-project
-
-# Use custom template from Acontext-Examples repository
+# With project name and custom template
 acontext create my-project --template-path "python/custom-template"
-# or
-acontext create my-project -t "typescript/my-custom-template"
 ```
 
-**Templates:**
+Templates are discovered from the [Acontext-Examples](https://github.com/memodb-io/Acontext-Examples) repository, organized by language (`python/`, `typescript/`).
 
-The CLI automatically discovers all available templates from the [Acontext-Examples](https://github.com/memodb-io/Acontext-Examples) repository. When you run `acontext create`, you'll see a list of all templates available for your selected language.
-
-Templates are organized by language:
-- `python/` - Python templates (openai, anthropic, etc.)
-- `typescript/` - TypeScript templates (vercel-ai, langchain, etc.)
-
-You can also use any custom template folder by specifying the path with `--template-path`.
-
-### Server Management (Split-Screen TUI)
-
-Start both sandbox and Docker services in a unified split-screen terminal interface:
+### Local Development
 
 ```bash
-# Start server with sandbox and docker in split-screen view
+# Start sandbox + Docker in split-screen TUI
 acontext server up
 ```
-
-The `server up` command will:
-- Check if `sandbox/cloudflare` exists, create it if missing
-- Start the sandbox development server
-- Start all Docker Compose services
-- Display both outputs in a split-screen terminal UI with real-time logs
-- Show Docker service status indicators (healthy/running/exited)
-- Support mouse wheel scrolling for both panels
 
 Press `q` or `Ctrl+C` to stop all services.
 
 ### Version Management
 
-```bash
-# Check version (automatically checks for updates)
-acontext version
-
-# Upgrade to the latest version
-acontext upgrade
-```
-
-The CLI automatically checks for updates after each command execution. If a new version is available, you'll see a notification prompting you to run `acontext upgrade`.
-
-## Environment Configuration
-
-When running `acontext server up`, if `.env` file doesn't exist, a default one will be created. You can edit it to configure:
-
-1. **LLM SDK**: `openai` or `anthropic`
-2. **LLM API Key**: Your API key for the selected SDK
-3. **LLM Base URL**: API endpoint (defaults to official API URLs)
-4. **Acontext API Token**: A string to build your Acontext API key (`sk-ac-<your-token>`)
-5. **Config File Path**: Optional path to a `config.yaml` file (copy `config.yaml.example` as a starting point)
-
-## Development Status
-
-**🎯 Current Progress**: Production Ready  
-**✅ Completed**: 
-- ✅ Interactive project creation
-- ✅ Multi-language template support (Python/TypeScript)
-- ✅ Dynamic template discovery from repository
-- ✅ Git repository initialization
-- ✅ Docker Compose integration with health checks
-- ✅ One-command deployment
-- ✅ Split-screen TUI for server management
-- ✅ Sandbox project management (Cloudflare)
-- ✅ Package manager auto-detection (pnpm, npm, yarn, bun)
-- ✅ Interactive .env configuration
-- ✅ Version checking and auto-update
-- ✅ CI/CD with GitHub Actions
-- ✅ Automated releases with GitHub Actions
-- ✅ Comprehensive unit tests
-- ✅ Telemetry for usage analytics
-
-## Command Reference
-
 | Command | Description |
 |---------|-------------|
-| `acontext create [name]` | Create a new project with templates |
-| `acontext server up` | Start sandbox + Docker in split-screen TUI |
 | `acontext version` | Show version info |
 | `acontext upgrade` | Upgrade to latest version |
-| `acontext help` | Show help information |
 
 ## License
 

--- a/src/client/acontext-cli/cmd/dash_ping.go
+++ b/src/client/acontext-cli/cmd/dash_ping.go
@@ -35,12 +35,7 @@ func init() {
 
 			if err := client.Ping(cmd.Context()); err != nil {
 				fmt.Printf("Ping failed for project %s: %v\n", dashProject, err)
-				fmt.Println()
-				fmt.Println("To fix this, re-select your project with a valid API key:")
-				fmt.Printf("  acontext dash projects select --project %s --api-key <sk-ac-...>\n", dashProject)
-				fmt.Println()
-				fmt.Println("The API key can be found on the Acontext Dashboard:")
-				fmt.Println("  https://dash.acontext.io")
+				fmt.Printf("Fix with: acontext dash projects select --project %s --api-key <sk-ac-...>\n", dashProject)
 				return fmt.Errorf("ping failed")
 			}
 

--- a/src/client/acontext-cli/cmd/dash_projects.go
+++ b/src/client/acontext-cli/cmd/dash_projects.go
@@ -14,10 +14,7 @@ import (
 
 // printSetupComplete prints the common message after a project is configured.
 func printSetupComplete() {
-	fmt.Println("API key saved to ~/.acontext/credentials.json")
-	fmt.Println()
-	fmt.Println("Verify connectivity:")
-	fmt.Println("  acontext dash ping")
+	fmt.Println("API key saved. Run 'acontext dash ping' to verify.")
 }
 
 func init() {
@@ -113,13 +110,8 @@ func init() {
 				if err := auth.SaveProjectKey(projectFlag, dashAccessToken, dashUserEmail, dashAdminClient); err != nil {
 					if errors.Is(err, auth.ErrNonTTYKeyRequired) {
 						// Non-TTY and no local key: prompt agent to ask user for the API key
-						fmt.Printf("No local API key found for project %s.\n", projectFlag)
-						fmt.Println()
-						fmt.Println("Please ask the user for the project's API key, then run:")
-						fmt.Printf("  acontext dash projects select --project %s --api-key <sk-ac-...>\n", projectFlag)
-						fmt.Println()
-						fmt.Println("The API key can be found on the Acontext Dashboard:")
-						fmt.Println("  https://dash.acontext.io")
+						fmt.Printf("No API key found for project %s.\n", projectFlag)
+						fmt.Printf("Provide one with: acontext dash projects select --project %s --api-key <sk-ac-...>\n", projectFlag)
 						return nil
 					}
 					return fmt.Errorf("save project key: %w", err)
@@ -132,8 +124,7 @@ func init() {
 			// Interactive mode: prompt user to select
 			choice, err := auth.SelectProject(dashAccessToken, dashUserID)
 			if errors.Is(err, auth.ErrNoProjects) {
-				fmt.Println("No projects found.")
-				fmt.Println("Create one first with: acontext dash projects create --name <name> --org <org-id>")
+				fmt.Println("No projects found. Create one with: acontext dash projects create --name <name> --org <org-id>")
 				return nil
 			}
 			if err != nil {
@@ -182,8 +173,7 @@ func init() {
 						orgID = newOrgID
 						fmt.Printf("Organization created: %s (%s)\n", orgName, orgID)
 					} else {
-						fmt.Println("No organizations found.")
-						fmt.Println("Create one first at https://dash.acontext.io, then retry.")
+						fmt.Println("No organizations found. Create one at https://dash.acontext.io first.")
 						return nil
 					}
 				} else if len(orgs) == 1 {

--- a/src/client/acontext-cli/cmd/login.go
+++ b/src/client/acontext-cli/cmd/login.go
@@ -14,7 +14,7 @@ import (
 var LoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in to Acontext Dashboard via browser",
-	Long:  "Authenticate with the Acontext Dashboard using browser-based OAuth. Tokens are stored in ~/.acontext/auth.json.",
+	Long:  "Authenticate with the Acontext Dashboard using browser-based OAuth.",
 	RunE:  runLogin,
 }
 
@@ -45,11 +45,9 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		}
 		af, _ := auth.Load()
 		if af != nil {
-			fmt.Printf("Login successful. Logged in as %s\n", af.User.Email)
-			fmt.Println("Credentials saved to ~/.acontext/auth.json")
+			fmt.Printf("Logged in as %s\n", af.User.Email)
 		}
-		fmt.Println()
-		fmt.Println("Next: set up a project. Run 'acontext dash projects list' to see available projects.")
+		fmt.Println("Next: run 'acontext dash projects list' to set up a project.")
 		return nil
 	}
 
@@ -90,7 +88,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			fmt.Println(tui.RenderWarning("No projects found."))
 			proceed, confirmErr := tui.RunConfirm("Create a new project?", true)
 			if confirmErr != nil || !proceed {
-				fmt.Println(tui.RenderInfo("You can create a project later with 'acontext dash projects create --name <name>'"))
+				fmt.Println(tui.RenderInfo("Run 'acontext dash projects create --name <name>' later."))
 				return nil
 			}
 
@@ -149,14 +147,12 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			}
 			return nil
 		} else if err != nil {
-			fmt.Println(tui.RenderWarning(fmt.Sprintf("Could not select project: %v", err)))
-			fmt.Println(tui.RenderInfo("You can select a project later with 'acontext dash projects select'"))
+			fmt.Println(tui.RenderWarning(fmt.Sprintf("Could not select project: %v. Run 'acontext dash projects select' later.", err)))
 			return nil
 		}
 
 		if err := auth.SaveProjectKey(choice.ProjectID, af.AccessToken, af.User.Email, adminClient); err != nil {
-			fmt.Println(tui.RenderWarning(fmt.Sprintf("Could not save API key: %v", err)))
-			fmt.Println(tui.RenderInfo("You can set up the project later with 'acontext dash projects select'"))
+			fmt.Println(tui.RenderWarning(fmt.Sprintf("Could not save API key: %v. Run 'acontext dash projects select' later.", err)))
 			return nil
 		}
 		fmt.Println(tui.RenderSuccess(fmt.Sprintf("Default project set to: %s", choice.Name)))
@@ -168,29 +164,17 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("login failed: %w", err)
 		}
 		fmt.Println()
-		fmt.Println("ACTION REQUIRED: Show the following login URL to the user and ask them to open it in their browser:")
+		fmt.Println("ACTION REQUIRED: Open this URL in the browser to log in:")
+		fmt.Printf("\n  %s\n", loginURL)
 		fmt.Println()
-		fmt.Printf("  %s\n", loginURL)
-		fmt.Println()
-		fmt.Println("After the user confirms they have completed login in the browser, run:")
-		fmt.Println()
+		fmt.Println("After login completes, run:")
 		fmt.Println("  acontext login --poll")
 		fmt.Println()
-		fmt.Println("This will retrieve the authentication tokens. Then proceed with project setup:")
-		fmt.Println()
-		fmt.Println("  1. Run 'acontext dash projects list' to see available projects.")
-		fmt.Println("  2. If projects exist, show them to the user as a numbered table")
-		fmt.Println("     (# | org_name | name | project_id) and ask which one to use.")
-		fmt.Println("     Ask the user for the project's API key (found on https://dash.acontext.io), then run:")
-		fmt.Println("       acontext dash projects select --project <project-id> --api-key <sk-ac-...>")
-		fmt.Println("  3. If the list is empty, ask the user for an org name and project name,")
-		fmt.Println("     then run:")
-		fmt.Println("       acontext dash projects create --name <project-name> --org <org-id>")
-		fmt.Println("     If no orgs exist either, the user must create one at https://dash.acontext.io first.")
-		fmt.Println("     The create output includes project_id and secret_key, auto-saved as default.")
-		fmt.Println("  4. After project setup, verify connectivity:")
-		fmt.Println("       acontext dash ping")
-		fmt.Println("     If ping fails, re-run 'acontext dash projects select' with the correct API key.")
+		fmt.Println("Then set up a project:")
+		fmt.Println("  1. acontext dash projects list")
+		fmt.Println("  2. acontext dash projects select --project <id> --api-key <sk-ac-...>")
+		fmt.Println("     Or create: acontext dash projects create --name <name> --org <org-id>")
+		fmt.Println("  3. acontext dash ping")
 	}
 
 	return nil
@@ -206,8 +190,7 @@ func runLogout(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("logout failed: %w", err)
 	}
 
-	fmt.Println(tui.RenderSuccess("Logged out successfully"))
-	fmt.Println(tui.RenderInfo("Removed ~/.acontext/auth.json and ~/.acontext/credentials.json"))
+	fmt.Println(tui.RenderSuccess("Logged out. Credentials removed."))
 	return nil
 }
 

--- a/src/client/acontext-cli/install.sh
+++ b/src/client/acontext-cli/install.sh
@@ -16,7 +16,7 @@ NC='\033[0m' # No Color
 REPO="memodb-io/Acontext"
 BINARY_NAME="acontext-cli"
 COMMAND_NAME="acontext"
-# Use ~/.acontext/bin for user installation (no sudo required)
+# User-local installation (no sudo required)
 # Falls back to /usr/local/bin if user explicitly wants system-wide install
 INSTALL_DIR="${HOME}/.acontext/bin"
 VERSION=""
@@ -354,7 +354,7 @@ while [ $# -gt 0 ]; do
             echo "  --system           Install system-wide to /usr/local/bin (requires sudo)"
             echo "  --help             Show this help message"
             echo ""
-            echo "By default, installs to ~/.acontext/bin and automatically updates your shell profile."
+            echo "By default, installs for the current user and automatically updates your shell profile."
             echo ""
             echo "Examples:"
             echo "  # Install latest version for current user (no sudo required)"


### PR DESCRIPTION
# Why we need this PR?

User-facing CLI messages and documentation exposed internal implementation details (`~/.acontext/credentials.json`, `~/.acontext/auth.json`, `~/.acontext/bin`) that users don't need to know about. Many CLI messages were also unnecessarily verbose (multi-line where one line suffices).

# Describe your solution

1. **Remove `~/.acontext/` path references** from all user-facing output: CLI messages, install script help text, SKILL.md, and CLI README.
2. **Simplify verbose CLI output** — collapse multi-line guidance into concise single-line messages (e.g. `printSetupComplete` went from 4 lines to 1, non-interactive login guide from 24 lines to 12).
3. **Rewrite CLI README** — add Quick Start guide, full command reference (auth, project management, skills, scaffolding, local dev, version management), remove outdated Development Status checklist.

Internal code comments in `internal/auth/` are left as-is since they're not user-facing.

# Implementation Tasks

- [x] Remove `~/.acontext/` from `landingpage/public/SKILL.md`
- [x] Remove `~/.acontext/` from `src/client/acontext-cli/install.sh`
- [x] Remove `~/.acontext/` from `src/client/acontext-cli/cmd/login.go`
- [x] Remove `~/.acontext/` from `src/client/acontext-cli/cmd/dash_projects.go`
- [x] Simplify verbose CLI messages in `login.go`, `dash_projects.go`, `dash_ping.go`
- [x] Rewrite `src/client/acontext-cli/README.md` with full command reference
- [x] Verify Go build passes

# Impact Areas

- [x] CLI Tool
- [x] Documentation
- [x] Other: Landing page SKILL.md

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)