### PR TITLE
feat(dashboard): add Usage page to organization sidebar

### DIFF
--- a/dashboard/app/org/[id]/org-layout-client.tsx
+++ b/dashboard/app/org/[id]/org-layout-client.tsx
@@ -2,7 +2,7 @@
 
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar, NavItem } from "@/components/app-sidebar";
-import { FolderKanban, Receipt, Settings, Users } from "lucide-react";
+import { BarChart3, FolderKanban, Receipt, Settings, Users } from "lucide-react";
 import { encodeId } from "@/lib/id-codec";
 
 interface OrgLayoutClientProps {
@@ -27,6 +27,12 @@ export function OrgLayoutClient({
       title: "Team",
       icon: Users,
       href: `/org/${organizationId}/team`,
+      exactMatch: false,
+    },
+    {
+      title: "Usage",
+      icon: BarChart3,
+      href: `/org/${organizationId}/usage`,
       exactMatch: false,
     },
     {

--- a/dashboard/app/org/[id]/usage/loading.tsx
+++ b/dashboard/app/org/[id]/usage/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-6xl">
+      <div className="flex flex-col gap-6">
+        {/* Header Skeleton */}
+        <div>
+          <Skeleton className="h-8 w-48 mb-2" />
+          <Skeleton className="h-4 w-96" />
+        </div>
+
+        {/* Plan & Period Card Skeleton */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-8 w-24" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Usage Cards Skeleton */}
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-2 w-full rounded-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/org/[id]/usage/page.tsx
+++ b/dashboard/app/org/[id]/usage/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { UsagePageClient } from "./usage-page-client";
+import { getOrganizationDataWithPlan, getOrganizationUsage } from "@/lib/supabase";
+import { decodeId } from "@/lib/id-codec";
+
+interface PageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default async function UsagePage({ params }: PageProps) {
+  const { id } = await params;
+  const actualId = decodeId(id);
+
+  let orgData;
+  try {
+    orgData = await getOrganizationDataWithPlan(actualId);
+  } catch {
+    notFound();
+  }
+
+  const { currentOrganization, allOrganizations } = orgData;
+
+  const usageData = await getOrganizationUsage(
+    currentOrganization.id!,
+    currentOrganization.plan || "free"
+  );
+
+  return (
+    <UsagePageClient
+      currentOrganization={currentOrganization}
+      allOrganizations={allOrganizations}
+      usageData={usageData}
+    />
+  );
+}

--- a/dashboard/app/org/[id]/usage/usage-page-client.tsx
+++ b/dashboard/app/org/[id]/usage/usage-page-client.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useTopNavStore } from "@/stores/top-nav";
+import { usePlanStore } from "@/stores/plan";
+import { Organization } from "@/types";
+import { OrganizationUsageData } from "@/lib/supabase/operations/organizations";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PlanType } from "@/stores/plan";
+
+interface UsagePageClientProps {
+  currentOrganization: Organization;
+  allOrganizations: Array<{ id: string; name: string; plan: PlanType }>;
+  usageData: OrganizationUsageData;
+}
+
+function formatStorage(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(value < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+}
+
+function getProgressColor(percentage: number): string {
+  if (percentage >= 90) return "bg-red-500";
+  if (percentage >= 70) return "bg-amber-500";
+  return "";
+}
+
+interface UsageMetric {
+  label: string;
+  description: string;
+  current: number;
+  max: number;
+  formatValue?: (v: number) => string;
+}
+
+function UsageCard({ metric }: { metric: UsageMetric }) {
+  const percentage = metric.max > 0 ? Math.min((metric.current / metric.max) * 100, 100) : 0;
+  const format = metric.formatValue || ((v: number) => v.toLocaleString());
+  const colorClass = getProgressColor(percentage);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-base">{metric.label}</CardTitle>
+            <CardDescription className="text-xs mt-0.5">
+              {metric.description}
+            </CardDescription>
+          </div>
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {format(metric.current)} / {metric.max > 0 ? format(metric.max) : "∞"}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="relative h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={`h-full rounded-full transition-all ${colorClass || "bg-primary"}`}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+        {percentage >= 90 && metric.max > 0 && (
+          <p className="text-xs text-red-500 mt-2">
+            {percentage >= 100
+              ? "Quota exceeded. Upgrade your plan to continue."
+              : "Approaching quota limit."}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function UsagePageClient({
+  currentOrganization,
+  allOrganizations,
+  usageData,
+}: UsagePageClientProps) {
+  const { initialize, setHasSidebar } = useTopNavStore();
+  const { getPriceByProduct, getPlanDisplayName: getPlanDisplayNameFromPrice } =
+    usePlanStore();
+
+  useEffect(() => {
+    initialize({
+      title: "",
+      organization: currentOrganization,
+      project: null,
+      organizations: allOrganizations,
+      projects: [],
+      hasSidebar: true,
+    });
+
+    return () => {
+      setHasSidebar(false);
+    };
+  }, [currentOrganization, allOrganizations, initialize, setHasSidebar]);
+
+  const getPlanDisplayName = (plan: string | undefined) => {
+    if (!plan || plan === "free") return "Free Plan";
+    const priceInfo = getPriceByProduct(plan);
+    if (priceInfo) {
+      const displayName = getPlanDisplayNameFromPrice(priceInfo);
+      return `${displayName} Plan`;
+    }
+    return `${plan.charAt(0).toUpperCase() + plan.slice(1)} Plan`;
+  };
+
+  const { usage, limits, period_end } = usageData;
+
+  const metrics: UsageMetric[] = [
+    {
+      label: "Agent Tasks",
+      description: "Total agent tasks created this billing period",
+      current: usage.current_task,
+      max: limits.max_task,
+    },
+    {
+      label: "Storage",
+      description: "Total storage used across all projects",
+      current: usage.current_storage,
+      max: limits.max_storage,
+      formatValue: formatStorage,
+    },
+  ];
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-6xl">
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-semibold">Usage</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Resource usage for the current billing period.
+          </p>
+        </div>
+
+        {/* Plan & Period */}
+        <Card>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Badge variant="secondary" className="text-base px-4 py-1">
+                  {getPlanDisplayName(currentOrganization.plan)}
+                </Badge>
+              </div>
+              {period_end && (
+                <p className="text-sm text-muted-foreground">
+                  Current period ends{" "}
+                  <span className="font-medium text-foreground">
+                    {new Date(period_end).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </span>
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Usage Metrics */}
+        {metrics.map((metric) => (
+          <UsageCard key={metric.label} metric={metric} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/lib/supabase/operations/index.ts
+++ b/dashboard/lib/supabase/operations/index.ts
@@ -42,7 +42,9 @@ export {
   addOrganizationMemberByEmail,
   removeOrganizationMember,
   getOrganizationDataWithPlan,
+  getOrganizationUsage,
   type OrganizationMember,
+  type OrganizationUsageData,
 } from "./organizations";
 
 // Project operations (Server Actions)

--- a/dashboard/lib/supabase/operations/organizations.ts
+++ b/dashboard/lib/supabase/operations/organizations.ts
@@ -319,6 +319,74 @@ export async function removeOrganizationMember(orgId: string, userId: string) {
 }
 
 /**
+ * Get organization usage and plan limits
+ */
+export interface OrganizationUsageData {
+  usage: {
+    current_task: number;
+    current_skill: number;
+    current_fast_skill_search: number;
+    current_agentic_skill_search: number;
+    current_storage: number;
+  };
+  limits: {
+    max_task: number;
+    max_skill: number;
+    max_fast_skill_search: number;
+    max_agentic_skill_search: number;
+    max_storage: number;
+  };
+  period_end: string | null;
+}
+
+export async function getOrganizationUsage(
+  orgId: string,
+  plan: string
+): Promise<OrganizationUsageData> {
+  const supabase = await createClient();
+
+  const [usageResult, limitsResult, billingResult] = await Promise.all([
+    supabase
+      .from("organization_usage")
+      .select("current_task, current_skill, current_fast_skill_search, current_agentic_skill_search, current_storage")
+      .eq("organization_id", orgId)
+      .single(),
+    supabase
+      .from("product_plans")
+      .select("max_task, max_skill, max_fast_skill_search, max_agentic_skill_search, max_storage")
+      .eq("plan", plan)
+      .single(),
+    supabase
+      .from("organization_billing")
+      .select("period_end")
+      .eq("organization_id", orgId)
+      .single(),
+  ]);
+
+  const usage = usageResult.data || {
+    current_task: 0,
+    current_skill: 0,
+    current_fast_skill_search: 0,
+    current_agentic_skill_search: 0,
+    current_storage: 0,
+  };
+
+  const limits = limitsResult.data || {
+    max_task: 0,
+    max_skill: 0,
+    max_fast_skill_search: 0,
+    max_agentic_skill_search: 0,
+    max_storage: 0,
+  };
+
+  return {
+    usage,
+    limits,
+    period_end: billingResult.data?.period_end || null,
+  };
+}
+
+/**
  * Helper function to transform organization membership data
  */
 function transformOrganizationFromMembership(


### PR DESCRIPTION
# Why we need this PR?

Add a Usage page to the organization dashboard so users can see their current plan's resource consumption at a glance.

# Describe your solution

- New `/org/[id]/usage` page showing current usage vs plan limits
- Displays **Agent Tasks** and **Storage** metrics (the two currently tracked resources)
- Progress bars with color coding: green (normal) → amber (70%+) → red (90%+)
- Current plan badge and billing period end date
- New `getOrganizationUsage()` server action that queries `organization_usage`, `product_plans`, and `organization_billing` tables in parallel
- Follows existing page patterns (server page.tsx → client component, loading skeleton)

# Implementation Tasks
- [x] Add `getOrganizationUsage` server action in `organizations.ts`
- [x] Create Usage page (server component + client component + loading skeleton)
- [x] Add "Usage" nav item to org sidebar between Team and Billing
- [x] Export new function and type from operations index

# Impact Areas
- [x] Dashboard

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.