### PR TITLE
fix(dashboard): concurrent chart group fetching & UsageIndicator crash fix

### DIFF
--- a/dashboard/app/api/dashboard-group/route.ts
+++ b/dashboard/app/api/dashboard-group/route.ts
@@ -1,0 +1,51 @@
+import {
+  getCurrentUser,
+  getProject,
+  getOrganizationMembershipForCurrentUser,
+} from "@/lib/supabase";
+import { AcontextClient } from "@/lib/acontext/server";
+import { type NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const projectId = searchParams.get("projectId");
+  const timeRange = searchParams.get("timeRange");
+  const fields = searchParams.get("fields");
+
+  if (!projectId || !timeRange || !fields) {
+    return Response.json({}, { status: 400 });
+  }
+
+  try {
+    await getCurrentUser();
+
+    const project = await getProject(projectId);
+    if (!project) {
+      return Response.json({}, { status: 403 });
+    }
+
+    const membership = await getOrganizationMembershipForCurrentUser(
+      project.organization_id,
+      "role"
+    );
+
+    if (!membership) {
+      return Response.json({}, { status: 403 });
+    }
+
+    const days = parseInt(timeRange, 10);
+    const client = new AcontextClient();
+    const data = await client.getDashboardData(
+      projectId,
+      days,
+      fields.split(",")
+    );
+
+    return Response.json(data);
+  } catch (error) {
+    console.error(
+      `Failed to fetch dashboard group [${fields}]: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+    return Response.json({}, { status: 500 });
+  }
+}

--- a/dashboard/app/project/[id]/actions.ts
+++ b/dashboard/app/project/[id]/actions.ts
@@ -111,43 +111,6 @@ export async function validateDashboardAccess(projectId: string): Promise<{
 }
 
 /**
- * Fetch a specific chart group's data
- */
-export async function fetchDashboardGroup(
-  projectId: string,
-  timeRange: TimeRange,
-  fields: string[]
-): Promise<Partial<DashboardData>> {
-  await getCurrentUser();
-
-  const project = await getProject(projectId);
-  if (!project) {
-    return {};
-  }
-
-  const membership = await getOrganizationMembershipForCurrentUser(
-    project.organization_id,
-    "role"
-  );
-
-  if (!membership) {
-    return {};
-  }
-
-  try {
-    const days = getDaysFromRange(timeRange);
-    const client = new AcontextClient();
-    const data = await client.getDashboardData(projectId, days, fields);
-    return data;
-  } catch (error) {
-    console.error(
-      `Failed to fetch dashboard group [${fields.join(",")}]: ${error instanceof Error ? error.message : "Unknown error"}`
-    );
-    return {};
-  }
-}
-
-/**
  * Fetch project statistics (task and skill counts)
  */
 export async function fetchProjectStatistics(projectId: string) {

--- a/dashboard/app/project/[id]/project-page-client.tsx
+++ b/dashboard/app/project/[id]/project-page-client.tsx
@@ -17,7 +17,6 @@ import { KeyRound } from "lucide-react";
 import {
   validateDashboardAccess,
   fetchProjectStatistics,
-  fetchDashboardGroup,
 } from "./actions";
 
 const CHART_GROUPS: Record<string, string[]> = {
@@ -84,7 +83,7 @@ export function ProjectPageClient({
 
   const prevTimeRangeRef = useRef(timeRange);
 
-  // Fire all 5 group fetches. Each resolves independently via .then()
+  // Fire all 5 group fetches via route handler — browser sends them concurrently
   const fetchAllGroups = useCallback(
     (tr: TimeRange, isMountedRef: { current: boolean }) => {
       setLoadingGroups(ALL_LOADING);
@@ -95,40 +94,34 @@ export function ProjectPageClient({
         }
       };
 
-      fetchDashboardGroup(project.id, tr, CHART_GROUPS.tasks).then((data) => {
-        if (isMountedRef.current) {
-          setTasksData(data);
-          setGroupLoading("tasks", false);
-        }
-      });
+      const fetchGroup = (
+        groupKey: keyof LoadingGroups,
+        fields: string[],
+        setter: (data: Partial<DashboardData>) => void
+      ) => {
+        const params = new URLSearchParams({
+          projectId: project.id,
+          timeRange: tr,
+          fields: fields.join(","),
+        });
+        fetch(`/api/dashboard-group?${params}`)
+          .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+          .then((data: Partial<DashboardData>) => {
+            if (isMountedRef.current) {
+              setter(data);
+              setGroupLoading(groupKey, false);
+            }
+          })
+          .catch(() => {
+            if (isMountedRef.current) setGroupLoading(groupKey, false);
+          });
+      };
 
-      fetchDashboardGroup(project.id, tr, CHART_GROUPS.session_metrics).then((data) => {
-        if (isMountedRef.current) {
-          setSessionMetricsData(data);
-          setGroupLoading("session_metrics", false);
-        }
-      });
-
-      fetchDashboardGroup(project.id, tr, CHART_GROUPS.task_metrics).then((data) => {
-        if (isMountedRef.current) {
-          setTaskMetricsData(data);
-          setGroupLoading("task_metrics", false);
-        }
-      });
-
-      fetchDashboardGroup(project.id, tr, CHART_GROUPS.storage).then((data) => {
-        if (isMountedRef.current) {
-          setStorageData(data);
-          setGroupLoading("storage", false);
-        }
-      });
-
-      fetchDashboardGroup(project.id, tr, CHART_GROUPS.counts).then((data) => {
-        if (isMountedRef.current) {
-          setCountsData(data);
-          setGroupLoading("counts", false);
-        }
-      });
+      fetchGroup("tasks", CHART_GROUPS.tasks, setTasksData);
+      fetchGroup("session_metrics", CHART_GROUPS.session_metrics, setSessionMetricsData);
+      fetchGroup("task_metrics", CHART_GROUPS.task_metrics, setTaskMetricsData);
+      fetchGroup("storage", CHART_GROUPS.storage, setStorageData);
+      fetchGroup("counts", CHART_GROUPS.counts, setCountsData);
     },
     [project.id]
   );
@@ -142,6 +135,8 @@ export function ProjectPageClient({
       if (isMountedRef.current) {
         setHasApiKey(result.hasApiKey);
       }
+    }).catch(() => {
+      // Access validation failed — leave hasApiKey as null (no dialog shown)
     });
 
     // 2. Fetch statistics
@@ -153,6 +148,8 @@ export function ProjectPageClient({
         }
         setStatsLoading(false);
       }
+    }).catch(() => {
+      if (isMountedRef.current) setStatsLoading(false);
     });
 
     // 3. Fire 5 group fetches in parallel

--- a/dashboard/components/top-nav.tsx
+++ b/dashboard/components/top-nav.tsx
@@ -301,25 +301,32 @@ function UsageIndicator({ className }: { className?: string }) {
   const [loading, setLoading] = React.useState(false);
   const [fetched, setFetched] = React.useState(false);
   const router = useRouter();
+  const user = useUserStore((s) => s.user);
 
-  const fetchUsage = React.useCallback(async () => {
-    if (fetched) return;
-    setLoading(true);
-    try {
-      const data = await getAllOrganizationsUsage();
-      setUsageData(data);
-      setFetched(true);
-    } catch {
-      // silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, [fetched]);
-
-  // Auto-fetch on mount to show warning dot
+  // Auto-fetch only after user is available in the store
   React.useEffect(() => {
-    fetchUsage();
-  }, [fetchUsage]);
+    if (fetched || !user) return;
+    let cancelled = false;
+
+    setLoading(true);
+    getAllOrganizationsUsage()
+      .then((data) => {
+        if (!cancelled) {
+          setUsageData(data);
+          setFetched(true);
+        }
+      })
+      .catch(() => {
+        // silently fail — redirect or network error
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetched, user]);
 
   // Check if any org has critical usage (>=90%)
   const hasWarning = React.useMemo(() => {


### PR DESCRIPTION
# Why we need this PR?

Two issues with the dashboard page:

1. **Server actions are serialized** — Next.js queues client-side server action calls, so the 5 `fetchDashboardGroup()` calls execute one-by-one instead of concurrently, defeating the per-card progressive loading UX.
2. **UsageIndicator crash on initial load** — The `UsageIndicator` component calls `getAllOrganizationsUsage()` (which internally calls `getCurrentUser()` → `redirect()`) before the user store is populated, causing a "Rendered more hooks than during the previous render" error during navigation.

# Describe your solution

1. **Route handler for chart groups**: Created `GET /api/dashboard-group` route handler that accepts `projectId`, `timeRange`, and `fields` query params. The client now uses `fetch()` instead of server actions, enabling the browser to fire all 5 requests concurrently.

2. **Deferred UsageIndicator fetch**: Added a `user` guard from `useUserStore` — `getAllOrganizationsUsage()` only fires after the user is available in the store. Also replaced `useCallback` + separate `useEffect` with a single `useEffect` using a `cancelled` flag to prevent state updates after unmount.

# Implementation Tasks

- [x] Create API route `dashboard/app/api/dashboard-group/route.ts` with auth checks
- [x] Update `project-page-client.tsx` to use `fetch()` instead of `fetchDashboardGroup` server action
- [x] Remove unused `fetchDashboardGroup` from `actions.ts`
- [x] Fix `UsageIndicator` to defer fetch until user store is populated

# Impact Areas

- [x] Dashboard

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.