### PR TITLE
fix(api): optimize slow SQL queries in asset_reference and session repos

### DIFF
--- a/src/server/api/go/internal/modules/repo/asset_reference.go
+++ b/src/server/api/go/internal/modules/repo/asset_reference.go
@@ -62,7 +62,6 @@ func (r *assetReferenceRepo) IncrementAssetRef(ctx context.Context, projectID uu
 				"ref_count": gorm.Expr("asset_references.ref_count + 1"),
 				// keep canonical s3 key if not set yet; otherwise preserve existing
 				"s3_key":             gorm.Expr("COALESCE(NULLIF(asset_references.s3_key, ''), EXCLUDED.s3_key)"),
-				"asset_meta":         row.AssetMeta,
 				"last_referenced_at": now,
 				"updated_at":         now,
 			}),

--- a/src/server/api/go/internal/modules/repo/session.go
+++ b/src/server/api/go/internal/modules/repo/session.go
@@ -195,7 +195,7 @@ func (r *sessionRepo) CreateMessageWithAssets(ctx context.Context, msg *model.Me
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// First get the message parent id in session
 		parent := model.Message{}
-		if err := tx.Where(&model.Message{SessionID: msg.SessionID}).Order("created_at desc").Limit(1).Find(&parent).Error; err == nil {
+		if err := tx.Select("id").Where(&model.Message{SessionID: msg.SessionID}).Order("created_at desc").Limit(1).Find(&parent).Error; err == nil {
 			if parent.ID != uuid.Nil {
 				msg.ParentID = &parent.ID
 			}


### PR DESCRIPTION
# Why we need this PR?

Production logs (2026-03-17~18) show 64 slow SQL entries (>200ms). This PR addresses 57 of them across two hot paths:

- **`asset_reference.go:70`** — 50 occurrences (200-460ms): `INSERT ON CONFLICT` was rewriting full `AssetMeta` JSONB (potentially KB-sized `Content` field) on every upsert conflict, even though existing rows already have the metadata.
- **`session.go:198/205`** — 7 occurrences: parent message lookup was doing `SELECT *` fetching large JSONB columns (`Meta`, `PartsAssetMeta`) when only `ID` is needed.

# Describe your solution

1. **`IncrementAssetRef`**: Removed `"asset_meta": row.AssetMeta` from the `ON CONFLICT DoUpdates` map. The `asset_meta` is written on INSERT (new row); on conflict the metadata is already stored — no need to overwrite it. Only `ref_count`, `s3_key`, `last_referenced_at`, `updated_at` are updated on conflict.

2. **`CreateMessageWithAssets`**: Added `.Select("id")` to the parent message query so only the `id` column is fetched instead of the full row with heavy JSONB fields.

3. **`auth.go`** (5 occurrences, ~300ms): Investigated but no change needed — `project.Configs` is used by downstream handlers and the occasional latency is PG contention on a uniqueIndex lookup.

# Implementation Tasks

- [x] Remove `asset_meta` from ON CONFLICT DoUpdates in `IncrementAssetRef`
- [x] Add `.Select("id")` to parent message lookup in `CreateMessageWithAssets`
- [x] Verify existing tests pass

# Impact Areas

- [x] API Server

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.