### PR TITLE
feat(api): wide event logging with GORM Zap bridge

### DIFF
--- a/src/server/api/go/internal/bootstrap/container.go
+++ b/src/server/api/go/internal/bootstrap/container.go
@@ -99,7 +99,7 @@ func BuildContainer() *do.Injector {
 	do.Provide(inj, func(i *do.Injector) (*gorm.DB, error) {
 		cfg := do.MustInvoke[*config.Config](i)
 		log := do.MustInvoke[*zap.Logger](i)
-		d, err := db.New(cfg)
+		d, err := db.New(cfg, log)
 		if err != nil {
 			return nil, err
 		}
@@ -283,6 +283,7 @@ func BuildContainer() *do.Injector {
 			do.MustInvoke[repo.ArtifactRepo](i),
 			do.MustInvoke[*blob.S3Deps](i),
 			do.MustInvoke[repo.AgentSkillsRepo](i),
+			do.MustInvoke[*zap.Logger](i),
 		), nil
 	})
 	do.Provide(inj, func(i *do.Injector) (service.TaskService, error) {

--- a/src/server/api/go/internal/infra/db/gorm.go
+++ b/src/server/api/go/internal/infra/db/gorm.go
@@ -6,15 +6,15 @@ import (
 	"time"
 
 	"github.com/memodb-io/Acontext/internal/config"
+	"go.uber.org/zap"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 	"gorm.io/plugin/opentelemetry/tracing"
 )
 
-func New(cfg *config.Config) (*gorm.DB, error) {
+func New(cfg *config.Config, log *zap.Logger) (*gorm.DB, error) {
 	gcfg := &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Warn),
+		Logger: NewZapGormLogger(log, 200*time.Millisecond),
 	}
 
 	// Adjust DSN sslmode based on EnableTLS configuration

--- a/src/server/api/go/internal/infra/db/gorm_logger.go
+++ b/src/server/api/go/internal/infra/db/gorm_logger.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// ZapGormLogger bridges GORM's logger interface to a Zap logger.
+// It logs slow queries at Warn level and errors at Error level.
+type ZapGormLogger struct {
+	log           *zap.Logger
+	slowThreshold time.Duration
+	logLevel      gormlogger.LogLevel
+}
+
+// NewZapGormLogger creates a GORM logger backed by Zap.
+// slowThreshold controls when a query is considered "slow" (default 200ms).
+func NewZapGormLogger(log *zap.Logger, slowThreshold time.Duration) *ZapGormLogger {
+	if slowThreshold <= 0 {
+		slowThreshold = 200 * time.Millisecond
+	}
+	return &ZapGormLogger{
+		log:           log.Named("gorm"),
+		slowThreshold: slowThreshold,
+		logLevel:      gormlogger.Warn,
+	}
+}
+
+func (l *ZapGormLogger) LogMode(level gormlogger.LogLevel) gormlogger.Interface {
+	cp := *l
+	cp.logLevel = level
+	return &cp
+}
+
+func (l *ZapGormLogger) Info(_ context.Context, msg string, data ...any) {
+	if l.logLevel >= gormlogger.Info {
+		l.log.Info(fmt.Sprintf(msg, data...))
+	}
+}
+
+func (l *ZapGormLogger) Warn(_ context.Context, msg string, data ...any) {
+	if l.logLevel >= gormlogger.Warn {
+		l.log.Warn(fmt.Sprintf(msg, data...))
+	}
+}
+
+func (l *ZapGormLogger) Error(_ context.Context, msg string, data ...any) {
+	if l.logLevel >= gormlogger.Error {
+		l.log.Error(fmt.Sprintf(msg, data...))
+	}
+}
+
+func (l *ZapGormLogger) Trace(_ context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
+	if l.logLevel <= gormlogger.Silent {
+		return
+	}
+
+	elapsed := time.Since(begin)
+	sql, rows := fc()
+
+	switch {
+	case err != nil && l.logLevel >= gormlogger.Error && !errors.Is(err, gormlogger.ErrRecordNotFound):
+		l.log.Error("query error",
+			zap.Error(err),
+			zap.String("sql", sql),
+			zap.Int64("rows", rows),
+			zap.Duration("elapsed", elapsed),
+		)
+	case elapsed >= l.slowThreshold && l.logLevel >= gormlogger.Warn:
+		l.log.Warn("slow query",
+			zap.String("sql", sql),
+			zap.Int64("rows", rows),
+			zap.Duration("elapsed", elapsed),
+			zap.Duration("threshold", l.slowThreshold),
+		)
+	}
+}

--- a/src/server/api/go/internal/infra/logger/zap.go
+++ b/src/server/api/go/internal/infra/logger/zap.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"os"
 	"strings"
 
 	"go.uber.org/zap"
@@ -21,5 +22,27 @@ func New(level string) (*zap.Logger, error) {
 	}
 	cfg.EncoderConfig.TimeKey = "timestamp"
 	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	// Embed environment context into every log line.
+	// These fields are captured once at startup and included automatically,
+	// enabling deployment-correlated debugging (wide event best practice).
+	cfg.InitialFields = envFields()
+
 	return cfg.Build()
+}
+
+// envFields reads deployment/environment metadata from well-known env vars.
+// Only non-empty values are included.
+func envFields() map[string]interface{} {
+	fields := make(map[string]interface{})
+	pairs := [][2]string{
+		{"service_version", "APP_SERVICE_VERSION"},
+		{"commit_hash", "APP_COMMIT_SHA"},
+	}
+	for _, p := range pairs {
+		if v := os.Getenv(p[1]); v != "" {
+			fields[p[0]] = v
+		}
+	}
+	return fields
 }

--- a/src/server/api/go/internal/middleware/auth.go
+++ b/src/server/api/go/internal/middleware/auth.go
@@ -89,6 +89,7 @@ func ProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
 		authSpan.End()
 
 		c.Set("project", &project)
+		SetWideEventField(c, "project_id", project.ID.String())
 		c.Next()
 	}
 }

--- a/src/server/api/go/internal/middleware/wide_event.go
+++ b/src/server/api/go/internal/middleware/wide_event.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+const wideEventKey = "wide_event"
+
+// WideEvent returns a middleware that emits a single structured "wide event"
+// (canonical log line) per request at completion. Other middleware and handlers
+// can enrich the event via SetWideEventField.
+//
+// This replaces scattered per-request log lines with one context-rich event,
+// following the canonical log lines pattern (https://stripe.com/blog/canonical-log-lines).
+func WideEvent(log *zap.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		// Initialize wide event on context
+		event := make(map[string]interface{}, 16)
+		event["method"] = c.Request.Method
+		event["path"] = c.Request.URL.Path
+		if q := c.Request.URL.RawQuery; q != "" {
+			event["query"] = q
+		}
+		event["client_ip"] = c.ClientIP()
+
+		// Attach trace/span ID from OpenTelemetry if available
+		span := trace.SpanFromContext(c.Request.Context())
+		if span.SpanContext().IsValid() {
+			event["trace_id"] = span.SpanContext().TraceID().String()
+			event["span_id"] = span.SpanContext().SpanID().String()
+		}
+
+		c.Set(wideEventKey, event)
+
+		// Process request
+		c.Next()
+
+		// Finalize event
+		latency := time.Since(start)
+		event["status"] = c.Writer.Status()
+		event["latency_ms"] = latency.Milliseconds()
+		event["response_size"] = c.Writer.Size()
+
+		// Collect any errors written to gin context
+		if len(c.Errors) > 0 {
+			event["gin_errors"] = c.Errors.String()
+		}
+
+		// Emit as structured fields
+		fields := make([]zap.Field, 0, len(event))
+		for k, v := range event {
+			fields = append(fields, zap.Any(k, v))
+		}
+
+		status := c.Writer.Status()
+		if status >= 500 {
+			log.Error("request", fields...)
+		} else {
+			log.Info("request", fields...)
+		}
+	}
+}
+
+// GetWideEvent retrieves the wide event map from the gin context.
+// Returns nil if the middleware is not active.
+func GetWideEvent(c *gin.Context) map[string]interface{} {
+	v, exists := c.Get(wideEventKey)
+	if !exists {
+		return nil
+	}
+	event, _ := v.(map[string]interface{})
+	return event
+}
+
+// SetWideEventField sets a single field on the wide event.
+// Safe to call even if the middleware is not active (no-op).
+func SetWideEventField(c *gin.Context, key string, value interface{}) {
+	if event := GetWideEvent(c); event != nil {
+		event[key] = value
+	}
+}

--- a/src/server/api/go/internal/modules/service/artifact.go
+++ b/src/server/api/go/internal/modules/service/artifact.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"mime/multipart"
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/memodb-io/Acontext/internal/infra/blob"
 	"github.com/memodb-io/Acontext/internal/modules/model"
 	"github.com/memodb-io/Acontext/internal/modules/repo"
@@ -35,19 +36,23 @@ type artifactService struct {
 	r               repo.ArtifactRepo
 	s3              *blob.S3Deps
 	agentSkillsRepo repo.AgentSkillsRepo
+	log             *zap.Logger
 }
 
-func NewArtifactService(r repo.ArtifactRepo, s3 *blob.S3Deps, agentSkillsRepo repo.AgentSkillsRepo) ArtifactService {
-	return &artifactService{r: r, s3: s3, agentSkillsRepo: agentSkillsRepo}
+func NewArtifactService(r repo.ArtifactRepo, s3 *blob.S3Deps, agentSkillsRepo repo.AgentSkillsRepo, log *zap.Logger) ArtifactService {
+	return &artifactService{r: r, s3: s3, agentSkillsRepo: agentSkillsRepo, log: log}
 }
 
-// touchSkillUpdatedAt is best-effort: logs a warning on failure but doesn't propagate the error.
+// touchSkillUpdatedAt is best-effort: logs a warning on failure but does not propagate the error.
 func (s *artifactService) touchSkillUpdatedAt(ctx context.Context, diskID uuid.UUID) {
 	if s.agentSkillsRepo == nil {
 		return
 	}
 	if err := s.agentSkillsRepo.TouchUpdatedAtByDiskID(ctx, diskID); err != nil {
-		log.Printf("[WARN] failed to touch skill updated_at for disk %s: %v", diskID, err)
+		s.log.Warn("failed to touch skill updated_at",
+			zap.String("disk_id", diskID.String()),
+			zap.Error(err),
+		)
 	}
 }
 

--- a/src/server/api/go/internal/modules/service/artifact_test.go
+++ b/src/server/api/go/internal/modules/service/artifact_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/memodb-io/Acontext/internal/modules/model"
 	"github.com/memodb-io/Acontext/internal/pkg/utils/fileparser"
 	"github.com/stretchr/testify/assert"
@@ -619,7 +621,7 @@ func TestArtifactService_GrepArtifacts(t *testing.T) {
 			mockRepo := new(MockArtifactRepo)
 			tt.setupMock(mockRepo)
 
-			svc := &artifactService{r: mockRepo}
+			svc := &artifactService{r: mockRepo, log: zap.NewNop()}
 
 			results, err := svc.GrepArtifacts(
 				context.Background(),
@@ -651,7 +653,7 @@ func TestArtifactService_TouchSkillUpdatedAt(t *testing.T) {
 		mockRepo.On("DeleteByPath", mock.Anything, projectID, diskID, "/test/", "file.txt").Return(nil)
 		mockSkillsRepo.On("TouchUpdatedAtByDiskID", mock.Anything, diskID).Return(nil)
 
-		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo}
+		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo, log: zap.NewNop()}
 		err := svc.DeleteByPath(context.Background(), projectID, diskID, "/test/", "file.txt")
 
 		assert.NoError(t, err)
@@ -665,7 +667,7 @@ func TestArtifactService_TouchSkillUpdatedAt(t *testing.T) {
 
 		mockRepo.On("DeleteByPath", mock.Anything, projectID, diskID, "/test/", "file.txt").Return(errors.New("delete failed"))
 
-		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo}
+		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo, log: zap.NewNop()}
 		err := svc.DeleteByPath(context.Background(), projectID, diskID, "/test/", "file.txt")
 
 		assert.Error(t, err)
@@ -683,7 +685,7 @@ func TestArtifactService_TouchSkillUpdatedAt(t *testing.T) {
 		mockRepo.On("Update", mock.Anything, mock.Anything).Return(nil)
 		mockSkillsRepo.On("TouchUpdatedAtByDiskID", mock.Anything, diskID).Return(nil)
 
-		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo}
+		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo, log: zap.NewNop()}
 		_, err := svc.UpdateArtifactMetaByPath(context.Background(), diskID, "/test/", "file.txt", map[string]interface{}{"key": "val"})
 
 		assert.NoError(t, err)
@@ -698,7 +700,7 @@ func TestArtifactService_TouchSkillUpdatedAt(t *testing.T) {
 		mockRepo.On("DeleteByPath", mock.Anything, projectID, diskID, "/test/", "file.txt").Return(nil)
 		mockSkillsRepo.On("TouchUpdatedAtByDiskID", mock.Anything, diskID).Return(errors.New("touch failed"))
 
-		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo}
+		svc := &artifactService{r: mockRepo, agentSkillsRepo: mockSkillsRepo, log: zap.NewNop()}
 		err := svc.DeleteByPath(context.Background(), projectID, diskID, "/test/", "file.txt")
 
 		// The artifact operation should still succeed even though touch failed
@@ -712,7 +714,7 @@ func TestArtifactService_TouchSkillUpdatedAt(t *testing.T) {
 
 		mockRepo.On("DeleteByPath", mock.Anything, projectID, diskID, "/test/", "file.txt").Return(nil)
 
-		svc := &artifactService{r: mockRepo, agentSkillsRepo: nil}
+		svc := &artifactService{r: mockRepo, agentSkillsRepo: nil, log: zap.NewNop()}
 		err := svc.DeleteByPath(context.Background(), projectID, diskID, "/test/", "file.txt")
 
 		assert.NoError(t, err)
@@ -810,7 +812,7 @@ func TestArtifactService_GlobArtifacts(t *testing.T) {
 			mockRepo := new(MockArtifactRepo)
 			tt.setupMock(mockRepo)
 
-			svc := &artifactService{r: mockRepo}
+			svc := &artifactService{r: mockRepo, log: zap.NewNop()}
 
 			results, err := svc.GlobArtifacts(
 				context.Background(),

--- a/src/server/api/go/internal/router/router.go
+++ b/src/server/api/go/internal/router/router.go
@@ -46,7 +46,7 @@ func NewRouter(d RouterDeps) *gin.Engine {
 		r.Use(middleware.TraceID())
 	}
 
-	r.Use(middleware.ZapLogger(d.Log))
+	r.Use(middleware.WideEvent(d.Log))
 
 	// health
 	r.GET("/health", func(c *gin.Context) { c.JSON(http.StatusOK, serializer.Response{Msg: "ok"}) })


### PR DESCRIPTION
# Why we need this PR?

Production log analysis (2026-03-17~18) revealed several logging gaps:
- Request logs missing `project_id`, `trace_id`, and deployment context
- GORM using its own default logger (not Zap), no slow query threshold configured
- `log.Printf` in `artifact.go` bypassing structured logging
- No environment context (commit hash, version) in any log line

# Describe your solution

Implement **canonical log lines** (wide events) following [Stripe's pattern](https://stripe.com/blog/canonical-log-lines): emit a single context-rich structured event per request at completion.

**Key changes:**
1. **Wide Event Middleware** (`middleware/wide_event.go`) — replaces `ZapLogger` middleware. Emits one log per request with: method, path, status, latency_ms, trace_id, span_id, project_id, client_ip, response_size. 5xx requests auto-elevated to `error` level.
2. **Environment Context** (`infra/logger/zap.go`) — `APP_SERVICE_VERSION` and `APP_COMMIT_SHA` env vars baked into every log line via Zap InitialFields.
3. **GORM Zap Bridge** (`infra/db/gorm_logger.go`) — custom GORM logger backed by Zap with 200ms slow query threshold. Logs slow queries at Warn and errors at Error with structured fields (sql, rows, elapsed).
4. **Auth Enrichment** (`middleware/auth.go`) — injects `project_id` into wide event after successful authentication.
5. **Fix log.Printf** (`service/artifact.go`) — replaced stdlib `log.Printf` with injected `*zap.Logger`.

# Implementation Tasks
- [x] Create wide event middleware with `GetWideEvent`/`SetWideEventField` helpers
- [x] Add environment context (version, commit hash) to Zap InitialFields
- [x] Replace `ZapLogger` with `WideEvent` in router
- [x] Enrich wide event with `project_id` in auth middleware
- [x] Create GORM Zap logger bridge with 200ms slow threshold
- [x] Replace `log.Printf` in artifact.go with structured Zap logger
- [x] Update tests for new `NewArtifactService` signature

# Impact Areas
- [x] API Server

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.