### PR TITLE
fix(plugins): rename ACONTEXT_USER_ID → ACONTEXT_USER_IDENTIFIER & remove unnecessary flush calls

### DIFF
--- a/docs/content/docs/integrations/claude-code.mdx
+++ b/docs/content/docs/integrations/claude-code.mdx
@@ -25,7 +25,7 @@ Get an API key from [dash.acontext.io](https://dash.acontext.io/) and export it 
 
 ```bash
 export ACONTEXT_API_KEY="<your-api-key>"
-export ACONTEXT_USER_ID="<your-login-email>"
+export ACONTEXT_USER_IDENTIFIER="<your-identifier>"
 ```
 
 </Step>
@@ -70,7 +70,7 @@ All settings are via environment variables:
 |---------|---------|-------------|
 | `ACONTEXT_API_KEY` | — | **Required.** Acontext API key |
 | `ACONTEXT_BASE_URL` | `https://api.acontext.app/api/v1` | API base URL |
-| `ACONTEXT_USER_ID` | `"default"` | Scope sessions per user |
+| `ACONTEXT_USER_IDENTIFIER` | `"claude_code"` | User identifier for session scoping |
 | `ACONTEXT_LEARNING_SPACE_ID` | auto-created | Explicit Learning Space ID |
 | `ACONTEXT_SKILLS_DIR` | `~/.claude/skills` | Directory where skills are synced |
 | `ACONTEXT_AUTO_CAPTURE` | `true` | Store messages after each agent turn |

--- a/docs/content/docs/integrations/openclaw.mdx
+++ b/docs/content/docs/integrations/openclaw.mdx
@@ -39,7 +39,7 @@ Add the Acontext plugin to your `openclaw.json` config:
         enabled: true,
         config: {
           "apiKey": "${ACONTEXT_API_KEY}",
-          "userId": "your-user-id"
+          "userIdentifier": "your-identifier"
         }
       }
     }
@@ -70,7 +70,7 @@ Session 1: User talks to agent
   └→ Learning Space distills skills as Markdown
 
   ── Compaction or reset occurs ──
-  └→ Pending messages flushed & learning triggered
+  └→ Learning triggered
   └→ Message cursor resets for next capture
 
 Session 2: User returns
@@ -84,8 +84,8 @@ The plugin hooks into four OpenClaw lifecycle events:
 
 - **`before_agent_start`** — Ensures learned skills are synced to `~/.openclaw/skills/` so OpenClaw can load them natively
 - **`agent_end`** — Stores new conversation messages to Acontext incrementally, triggers task extraction, and conditionally triggers skill distillation
-- **`before_compaction`** — Flushes pending messages and triggers learning before OpenClaw compacts the conversation history, then flags the message cursor for reset
-- **`before_reset`** — Flushes pending messages and triggers learning before a session reset clears the transcript, then flags the message cursor for reset
+- **`before_compaction`** — Triggers learning before OpenClaw compacts the conversation history, then flags the message cursor for reset
+- **`before_reset`** — Triggers learning before a session reset clears the transcript, then flags the message cursor for reset
 
 <Note>
 Message capture is incremental — the plugin tracks a cursor so only new messages are stored on each `agent_end`. When compaction or reset rewrites the transcript, the cursor resets automatically to avoid gaps or duplicates.
@@ -97,7 +97,7 @@ Message capture is incremental — the plugin tracks a cursor so only new messag
 |-----|------|---------|-------------|
 | `apiKey` | `string` | — | **Required.** Acontext API key (supports `${ACONTEXT_API_KEY}`) |
 | `baseUrl` | `string` | `https://api.acontext.app/api/v1` | Acontext API base URL |
-| `userId` | `string` | `"default"` | Scope sessions per user |
+| `userIdentifier` | `string` | `"openclaw"` | User identifier for session scoping |
 | `learningSpaceId` | `string` | auto-created | Explicit Learning Space ID |
 | `skillsDir` | `string` | `~/.openclaw/skills` | Directory where skills are synced for native loading |
 | `autoCapture` | `boolean` | `true` | Store messages after each turn |

--- a/landingpage/public/SKILL.md
+++ b/landingpage/public/SKILL.md
@@ -144,6 +144,7 @@ After `acontext login`, the plugin works automatically. The following env vars c
 
 | Env Var                        | Default                           | Description                            |
 | ------------------------------ | --------------------------------- | -------------------------------------- |
+| `ACONTEXT_USER_IDENTIFIER`     | `"claude_code"`                   | User identifier for session scoping    |
 | `ACONTEXT_BASE_URL`            | `https://api.acontext.app/api/v1` | API base URL                           |
 | `ACONTEXT_LEARNING_SPACE_ID`   | auto-created                      | Explicit Learning Space ID             |
 | `ACONTEXT_SKILLS_DIR`          | `~/.claude/skills`                | Directory where skills are synced      |
@@ -169,6 +170,7 @@ After `acontext login`, the plugin works automatically. Optional overrides in `o
 
 | Key                | Type      | Default                           | Description                              |
 | ------------------ | --------- | --------------------------------- | ---------------------------------------- |
+| `userIdentifier`   | `string`  | `"openclaw"`                      | User identifier for session scoping      |
 | `baseUrl`          | `string`  | `https://api.acontext.app/api/v1` | API base URL                             |
 | `learningSpaceId`  | `string`  | auto-created                      | Explicit Learning Space ID               |
 | `skillsDir`        | `string`  | `~/.openclaw/skills`              | Directory where skills are synced        |

--- a/src/packages/claude-code/README.md
+++ b/src/packages/claude-code/README.md
@@ -24,7 +24,7 @@ Get an API key from [dash.acontext.io](https://dash.acontext.io/) and set it in 
 
 ```bash
 export ACONTEXT_API_KEY=sk-ac-your-api-key
-export ACONTEXT_USER_ID=your-user-id
+export ACONTEXT_USER_IDENTIFIER=your-identifier
 ```
 
 Restart Claude Code — the plugin auto-captures conversations and syncs skills to `~/.claude/skills/`.
@@ -37,7 +37,7 @@ All settings are via environment variables:
 |---------|---------|-------------|
 | `ACONTEXT_API_KEY` | — | **Required.** Acontext API key |
 | `ACONTEXT_BASE_URL` | `https://api.acontext.app/api/v1` | Acontext API base URL |
-| `ACONTEXT_USER_ID` | `"default"` | Scope sessions per user |
+| `ACONTEXT_USER_IDENTIFIER` | `"claude_code"` | User identifier for session scoping |
 | `ACONTEXT_LEARNING_SPACE_ID` | auto-created | Explicit Learning Space ID |
 | `ACONTEXT_SKILLS_DIR` | `~/.claude/skills` | Directory where skills are synced for native loading |
 | `ACONTEXT_AUTO_CAPTURE` | `true` | Store messages after each turn |
@@ -68,7 +68,7 @@ Session 1: User talks to Claude Code
   └→ Auto-learn triggers at turn threshold (default: 4)
 
 Session end:
-  └→ [stop hook] Final message capture, flush, learning triggered
+  └→ [stop hook] Final message capture, learning triggered
   └→ Newly learned skills synced to ~/.claude/skills/
 
 Session 2: User returns

--- a/src/packages/claude-code/plugin/scripts/hook-handler.cjs
+++ b/src/packages/claude-code/plugin/scripts/hook-handler.cjs
@@ -21041,7 +21041,7 @@ function loadConfig() {
       "ACONTEXT_API_KEY is required. Set it in your shell profile, or run 'acontext login' to configure ~/.acontext/credentials.json."
     );
   }
-  const userId = loadUserIdFromAuth() || process.env.ACONTEXT_USER_ID?.trim() || "default";
+  const userId = (process.env.ACONTEXT_USER_IDENTIFIER ?? process.env.ACONTEXT_USER_ID)?.trim() || loadUserIdFromAuth() || "claude_code";
   return {
     apiKey,
     baseUrl: process.env.ACONTEXT_BASE_URL?.trim() || "https://api.acontext.app/api/v1",
@@ -21255,7 +21255,6 @@ async function handlePostToolUse(bridge, config, lockDir) {
     }
     if (config.autoLearn && bridge.getTurnCount() >= config.minTurnsForLearn) {
       try {
-        await bridge.flush(sessionId);
         const result = await bridge.learnFromSession(sessionId);
         if (result.status === "learned") {
           logger.info(
@@ -21317,12 +21316,6 @@ async function handleStop(bridge, config, lockDir) {
           }
         }
       }
-    }
-    try {
-      await bridge.flush(sessionId);
-      logger.info(`acontext: session flushed: ${sessionId}`);
-    } catch (err) {
-      logger.warn(`acontext: flush failed: ${String(err)}`);
     }
     if (config.autoLearn) {
       try {

--- a/src/packages/claude-code/plugin/scripts/mcp-server.cjs
+++ b/src/packages/claude-code/plugin/scripts/mcp-server.cjs
@@ -52179,7 +52179,7 @@ function loadConfig() {
       "ACONTEXT_API_KEY is required. Set it in your shell profile, or run 'acontext login' to configure ~/.acontext/credentials.json."
     );
   }
-  const userId = loadUserIdFromAuth() || process.env.ACONTEXT_USER_ID?.trim() || "default";
+  const userId = (process.env.ACONTEXT_USER_IDENTIFIER ?? process.env.ACONTEXT_USER_ID)?.trim() || loadUserIdFromAuth() || "claude_code";
   return {
     apiKey,
     baseUrl: process.env.ACONTEXT_BASE_URL?.trim() || "https://api.acontext.app/api/v1",

--- a/src/packages/claude-code/src/__tests__/config.test.ts
+++ b/src/packages/claude-code/src/__tests__/config.test.ts
@@ -12,6 +12,8 @@ describe("loadConfig", () => {
     // Create a temp dir so real ~/.acontext/ files don't interfere
     tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-code-test-"));
     process.env = { ...originalEnv, ACONTEXT_API_KEY: "test-key-123", ACONTEXT_CONFIG_DIR: tmpConfigDir };
+    delete process.env.ACONTEXT_USER_IDENTIFIER;
+    delete process.env.ACONTEXT_USER_ID;
   });
 
   afterEach(() => {
@@ -32,14 +34,36 @@ describe("loadConfig", () => {
     expect(loadConfig().apiKey).toBe("env-key");
   });
 
-  it("falls back to auth.json for userId when ACONTEXT_USER_ID is not set", async () => {
-    delete process.env.ACONTEXT_USER_ID;
+  it("falls back to auth.json for userId when env var is not set", async () => {
     fs.writeFileSync(
       path.join(tmpConfigDir, "auth.json"),
       JSON.stringify({ user: { email: "user@test.com" } }),
     );
     const { loadConfig } = await import("../config");
     expect(loadConfig().userId).toBe("user@test.com");
+  });
+
+  it("env var ACONTEXT_USER_IDENTIFIER takes priority over auth.json", async () => {
+    process.env.ACONTEXT_USER_IDENTIFIER = "env-user";
+    fs.writeFileSync(
+      path.join(tmpConfigDir, "auth.json"),
+      JSON.stringify({ user: { email: "auth@test.com" } }),
+    );
+    const { loadConfig } = await import("../config");
+    expect(loadConfig().userId).toBe("env-user");
+  });
+
+  it("legacy ACONTEXT_USER_ID works as fallback when ACONTEXT_USER_IDENTIFIER is not set", async () => {
+    process.env.ACONTEXT_USER_ID = "legacy-user";
+    const { loadConfig } = await import("../config");
+    expect(loadConfig().userId).toBe("legacy-user");
+  });
+
+  it("ACONTEXT_USER_IDENTIFIER takes priority over legacy ACONTEXT_USER_ID", async () => {
+    process.env.ACONTEXT_USER_IDENTIFIER = "new-user";
+    process.env.ACONTEXT_USER_ID = "legacy-user";
+    const { loadConfig } = await import("../config");
+    expect(loadConfig().userId).toBe("new-user");
   });
 
   it("credentials.json takes priority over env var", async () => {
@@ -71,9 +95,8 @@ describe("loadConfig", () => {
   });
 
   it("uses default userId when env and auth.json are not available", async () => {
-    delete process.env.ACONTEXT_USER_ID;
     const { loadConfig } = await import("../config");
-    expect(loadConfig().userId).toBe("default");
+    expect(loadConfig().userId).toBe("claude_code");
   });
 
   it("reads learningSpaceId from env", async () => {

--- a/src/packages/claude-code/src/config.ts
+++ b/src/packages/claude-code/src/config.ts
@@ -1,6 +1,6 @@
 /**
  * Configuration for the Acontext Claude Code plugin.
- * Values are resolved with priority: ~/.acontext/ files > environment variables > defaults.
+ * Values are resolved with priority: environment variables > ~/.acontext/ files > defaults.
  */
 
 import * as fs from "node:fs";
@@ -52,7 +52,8 @@ function loadApiKeyFromCredentials(): string | undefined {
 }
 
 /**
- * Read auth.json and return the user's email.
+ * Read auth.json and return the user's email as a fallback identifier.
+ * Used when no explicit env var or plugin config is set.
  */
 function loadUserIdFromAuth(): string | undefined {
   try {
@@ -76,8 +77,8 @@ export function loadConfig(): AcontextConfig {
     );
   }
 
-  // Priority: ~/.acontext/auth.json > env var > "default"
-  const userId = loadUserIdFromAuth() || process.env.ACONTEXT_USER_ID?.trim() || "default";
+  // Priority: env var > ~/.acontext/auth.json > "default"
+  const userId = (process.env.ACONTEXT_USER_IDENTIFIER ?? process.env.ACONTEXT_USER_ID)?.trim() || loadUserIdFromAuth() || "claude_code";
 
   return {
     apiKey,

--- a/src/packages/claude-code/src/hook-handler.ts
+++ b/src/packages/claude-code/src/hook-handler.ts
@@ -123,7 +123,6 @@ async function handlePostToolUse(
       bridge.getTurnCount() >= config.minTurnsForLearn
     ) {
       try {
-        await bridge.flush(sessionId);
         const result = await bridge.learnFromSession(sessionId);
         if (result.status === "learned") {
           logger.info(
@@ -204,13 +203,6 @@ async function handleStop(
           }
         }
       }
-    }
-
-    try {
-      await bridge.flush(sessionId);
-      logger.info(`acontext: session flushed: ${sessionId}`);
-    } catch (err) {
-      logger.warn(`acontext: flush failed: ${String(err)}`);
     }
 
     // Intentionally skip minTurnsForLearn check here — Stop should always

--- a/src/packages/openclaw/index.ts
+++ b/src/packages/openclaw/index.ts
@@ -84,6 +84,7 @@ export function resolveEnvVars(value: string): string {
 const ALLOWED_KEYS = [
   "apiKey",
   "baseUrl",
+  "userIdentifier",
   "userId",
   "learningSpaceId",
   "skillsDir",
@@ -171,11 +172,11 @@ export const configSchema = {
       );
     }
 
-    // Resolve userId: ~/.acontext/auth.json > config > "default"
-    const userId =
-      loadUserIdFromAuth() ||
-      (typeof cfg.userId === "string" && cfg.userId ? cfg.userId : undefined) ||
-      "default";
+    // Resolve userIdentifier: plugin config (userIdentifier > userId) > auth.json > "default"
+    const userIdentifier =
+      (typeof cfg.userIdentifier === "string" && cfg.userIdentifier ? cfg.userIdentifier : undefined) ||
+      (typeof cfg.userId === "string" && cfg.userId ? cfg.userId : undefined);
+    const userId = userIdentifier || loadUserIdFromAuth() || "openclaw";
 
     return {
       apiKey: resolvedApiKey,
@@ -1359,28 +1360,27 @@ const acontextPlugin = {
 
     // Flush + learn before session is compacted or reset to avoid losing data
     if (cfg.autoCapture) {
-      const flushAndLearnIfActive = async () => {
+      const learnIfActive = async () => {
         if (!currentAcontextSessionId || !cfg.autoLearn) return;
         try {
-          await bridge.flush(currentAcontextSessionId);
           const result = await bridge.learnFromSession(currentAcontextSessionId);
           if (result.status === "learned") {
             api.logger.info(`acontext: pre-clear learn triggered (learning: ${result.id})`);
           }
         } catch (err) {
-          api.logger.warn(`acontext: pre-clear flush/learn failed: ${String(err)}`);
+          api.logger.warn(`acontext: pre-clear learn failed: ${String(err)}`);
         }
       };
 
       api.on("before_compaction", async (_event, _ctx) => {
-        await flushAndLearnIfActive();
+        await learnIfActive();
         // Compaction rewrites the message history — flag a cursor reset
         // so the next agent_end re-baselines instead of using the stale offset.
         pendingCursorReset = true;
       });
 
       api.on("before_reset", async (_event, _ctx) => {
-        await flushAndLearnIfActive();
+        await learnIfActive();
         // Clear session binding so the next agent_end creates a fresh session.
         if (currentOpenClawSessionKey) {
           bridge.clearSessionMapping(currentOpenClawSessionKey);
@@ -1447,15 +1447,7 @@ const acontextPlugin = {
             capturedTurnCount = 0;
 
             bridge
-              .flush(learnSessionId)
-              .then((flushResult) => {
-                if (flushResult.status !== 0) {
-                  api.logger.warn(
-                    `acontext: flush returned non-zero status before auto-learn: ${flushResult.errmsg}`,
-                  );
-                }
-                return bridge.learnFromSession(learnSessionId);
-              })
+              .learnFromSession(learnSessionId)
               .then((result) => {
                 if (result.status === "learned") {
                   api.logger.info(

--- a/src/packages/openclaw/tests/plugin.test.ts
+++ b/src/packages/openclaw/tests/plugin.test.ts
@@ -104,7 +104,7 @@ describe("configSchema.parse", () => {
       apiKey: "${ACONTEXT_API_KEY}",
     });
     expect(cfg.apiKey).toBe("sk-ac-test");
-    expect(cfg.userId).toBe("default");
+    expect(cfg.userId).toBe("openclaw");
     expect(cfg.baseUrl).toBe("https://api.acontext.app/api/v1");
   });
 
@@ -219,7 +219,7 @@ describe("configSchema.parse", () => {
     }));
     const cfg = configSchema.parse({});
     expect(cfg.apiKey).toBe("sk-ac-from-creds");
-    expect(cfg.userId).toBe("default");
+    expect(cfg.userId).toBe("openclaw");
   });
 
   test("parses empty config and reads userId from auth.json", async () => {


### PR DESCRIPTION
# Why we need this PR?

Two issues in the claude-code and openclaw plugins:
1. `ACONTEXT_USER_ID` is misleading — it's actually an identifier/tag for session scoping, not a login user ID. Priority was also inverted (auth.json winning over explicit env/config).
2. `flush()` is blocking and called in auto-learn paths unnecessarily. The server processes learning asynchronously via RabbitMQ workers, so flush is only needed for explicit user-triggered tools.

# Describe your solution

### Issue 1: Rename & fix priority
- **Claude Code**: New env var `ACONTEXT_USER_IDENTIFIER` (with `ACONTEXT_USER_ID` as legacy fallback). Priority: `env var > auth.json > "claude_code"`.
- **OpenClaw**: New config key `userIdentifier` (with `userId` as legacy fallback). Priority: `plugin config > auth.json > "openclaw"`.
- Default identifiers are now platform-specific (`claude_code` / `openclaw`) instead of generic `"default"`.

### Issue 2: Remove unnecessary flush calls
- Removed `flush()` from auto-learn (post-tool-use hook, agent_end), stop handler, and compaction/reset paths.
- Kept `flush()` only in explicit `learn_now` MCP tools where the user expects synchronous results.
- Renamed `flushAndLearnIfActive` → `learnIfActive` in openclaw.

# Implementation Tasks
- [x] Rename env var / config key with legacy fallback in both plugins
- [x] Fix identifier resolution priority in both plugins
- [x] Change default identifiers to platform-specific values
- [x] Remove flush() from 4 automatic paths (2 in claude-code, 2 in openclaw)
- [x] Update tests (3 new tests in claude-code, 2 updated in openclaw)
- [x] Update docs (README, claude-code.mdx, openclaw.mdx, SKILL.md)
- [x] Rebuild claude-code bundles

# Impact Areas
- [x] Documentation
- [x] Other: Claude Code Plugin, OpenClaw Plugin

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.