### PR TITLE
fix(api): prevent GORM AutoMigrate from issuing ALTER TABLE on every pod startup

### DIFF
--- a/src/server/api/go/internal/modules/model/asset_reference.go
+++ b/src/server/api/go/internal/modules/model/asset_reference.go
@@ -23,7 +23,7 @@ type AssetReference struct {
 
 	// SHA256 hash as unique identifier for content-based deduplication
 	// Combined with ProjectID as composite unique key
-	SHA256 string `gorm:"type:char(64);not null;uniqueIndex:idx_project_sha256,priority:2" json:"sha256"`
+	SHA256 string `gorm:"type:varchar(64);not null;uniqueIndex:idx_project_sha256,priority:2" json:"sha256"`
 
 	// Canonical S3 key - the first uploaded location or preferred location
 	// When same content is uploaded multiple times within a project, we keep only one copy

--- a/src/server/api/go/internal/modules/model/project.go
+++ b/src/server/api/go/internal/modules/model/project.go
@@ -9,7 +9,7 @@ import (
 
 type Project struct {
 	ID               uuid.UUID         `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	SecretKeyHMAC    string            `gorm:"type:char(64);uniqueIndex;not null" json:"-"`
+	SecretKeyHMAC    string            `gorm:"type:varchar(64);uniqueIndex;not null" json:"-"`
 	SecretKeyHashPHC string            `gorm:"type:varchar(255);not null" json:"-"`
 	Configs          datatypes.JSONMap `gorm:"type:jsonb;index:idx_projects_configs,type:gin" swaggertype:"object" json:"configs"`
 


### PR DESCRIPTION
# Why we need this PR?

GORM AutoMigrate issues `ALTER TABLE ... ALTER COLUMN TYPE char(64)` on **every pod startup** because PostgreSQL stores `char(64)` internally as `bpchar`, and GORM sees a type mismatch. This ALTER acquires an **ACCESS EXCLUSIVE** lock on the table, blocking all reads and writes, which causes:

1. All queries against `projects` and `asset_references` tables to queue up waiting for the lock
2. DB connection pool exhaustion (`SQLSTATE 53300: remaining connection slots are reserved`)
3. Cascading S3 upload failures (`PutObject context canceled`)
4. 500 errors on `/api/v1/session/*/messages` endpoints

Production log analysis (2026-03-20) showed 432 slow queries, 145 errors, and 6 connection pool exhaustion events during a ~3 hour window, all traced back to this root cause.

# Describe your solution

Change GORM model column types from `char(64)` to `varchar(64)`. PostgreSQL's `varchar` type name matches what GORM expects, so AutoMigrate will see the types are consistent and **skip the ALTER**.

- `Project.SecretKeyHMAC`: `char(64)` → `varchar(64)`
- `AssetReference.SHA256`: `char(64)` → `varchar(64)`

Core (Python SQLAlchemy) already uses `String(64)` which maps to `varchar(64)` — no change needed there.

**Deployment note**: Before deploying, run these on the production database to avoid one final ALTER during the first pod startup:
```sql
ALTER TABLE projects ALTER COLUMN secret_key_hmac TYPE varchar(64);
ALTER TABLE asset_references ALTER COLUMN sha256 TYPE varchar(64);
```

# Implementation Tasks
- [x] Change `Project.SecretKeyHMAC` gorm tag from `type:char(64)` to `type:varchar(64)`
- [x] Change `AssetReference.SHA256` gorm tag from `type:char(64)` to `type:varchar(64)`

# Impact Areas
- [x] API Server

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)