### PR TITLE
feat(core): add litellm as LLM proxy for model-agnostic completion (fixes #91)

### DIFF
--- a/src/server/core/acontext_core/llm/complete/__init__.py
+++ b/src/server/core/acontext_core/llm/complete/__init__.py
@@ -1,6 +1,7 @@
 from typing import Callable, Awaitable, Mapping, Optional
 from .openai_sdk import openai_complete
 from .anthropic_sdk import anthropic_complete
+from .litellm_sdk import litellm_complete
 from .mock_sdk import mock_complete
 from ...schema.llm import LLMResponse
 from ...schema.result import Result
@@ -13,6 +14,7 @@ COMPLETE_FUNC = Callable[..., Awaitable[LLMResponse]]
 FACTORIES: Mapping[str, COMPLETE_FUNC] = {
     "openai": openai_complete,
     "anthropic": anthropic_complete,
+    "litellm": litellm_complete,
     "mock": mock_complete,
 }
 
@@ -62,6 +64,9 @@ async def llm_sanity_check():
 
 def response_to_sendable_message(message: LLMResponse) -> dict:
     if DEFAULT_CORE_CONFIG.llm_sdk == "openai":
+        return message.raw_response.choices[0].message.model_dump()
+    elif DEFAULT_CORE_CONFIG.llm_sdk == "litellm":
+        # litellm returns OpenAI-compatible ModelResponse
         return message.raw_response.choices[0].message.model_dump()
     elif DEFAULT_CORE_CONFIG.llm_sdk == "anthropic":
         dp = {"role": message.role, "content": []}

--- a/src/server/core/acontext_core/llm/complete/litellm_sdk.py
+++ b/src/server/core/acontext_core/llm/complete/litellm_sdk.py
@@ -1,0 +1,131 @@
+import json
+from typing import Optional
+from time import perf_counter
+
+import litellm
+
+from ...env import LOG, DEFAULT_CORE_CONFIG
+from ...schema.llm import LLMResponse
+from ...telemetry.log import get_wide_event
+
+
+# Silence litellm's own logging to avoid duplicate noise
+litellm.suppress_debug_info = True
+
+
+async def litellm_complete(
+    prompt=None,
+    model=None,
+    system_prompt=None,
+    history_messages=[],
+    json_mode=False,
+    max_tokens=1024,
+    prompt_kwargs: Optional[dict] = None,
+    tools=None,
+    **kwargs,
+) -> LLMResponse:
+    """
+    LLM completion via litellm — supports 100+ providers with a unified
+    OpenAI-compatible interface.
+
+    litellm accepts OpenAI-format messages/tools and returns OpenAI-format
+    responses, so minimal conversion is needed.
+    """
+    prompt_kwargs = prompt_kwargs or {}
+    prompt_id = prompt_kwargs.get("prompt_id", "...")
+
+    if json_mode:
+        kwargs["response_format"] = {"type": "json_object"}
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.extend(history_messages)
+    if prompt:
+        messages.append({"role": "user", "content": prompt})
+
+    if not messages:
+        raise ValueError("No messages provided")
+
+    # Build litellm call kwargs
+    call_kwargs = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "timeout": DEFAULT_CORE_CONFIG.llm_response_timeout,
+        **kwargs,
+    }
+
+    # Pass API key and base URL if configured
+    if DEFAULT_CORE_CONFIG.llm_api_key:
+        call_kwargs["api_key"] = DEFAULT_CORE_CONFIG.llm_api_key
+    if DEFAULT_CORE_CONFIG.llm_base_url:
+        call_kwargs["api_base"] = DEFAULT_CORE_CONFIG.llm_base_url
+
+    if tools:
+        call_kwargs["tools"] = tools
+
+    _start_s = perf_counter()
+    response = await litellm.acompletion(**call_kwargs)
+    _end_s = perf_counter()
+
+    # Extract token usage
+    _input = getattr(response.usage, "prompt_tokens", 0) or 0
+    _output = getattr(response.usage, "completion_tokens", 0) or 0
+    _cached = 0
+    if hasattr(response.usage, "prompt_tokens_details") and response.usage.prompt_tokens_details:
+        _cached = getattr(response.usage.prompt_tokens_details, "cached_tokens", 0) or 0
+
+    wide = get_wide_event()
+    wide["llm_input_tokens"] = wide.get("llm_input_tokens", 0) + _input
+    wide["llm_output_tokens"] = wide.get("llm_output_tokens", 0) + _output
+    wide["llm_cached_tokens"] = wide.get("llm_cached_tokens", 0) + _cached
+
+    LOG.info(
+        "llm.complete",
+        prompt_id=prompt_id,
+        model=model,
+        cached_tokens=_cached,
+        input_tokens=_input,
+        output_tokens=_output,
+        total_tokens=_input + _output,
+        duration_s=round(_end_s - _start_s, 4),
+    )
+
+    # litellm returns OpenAI-compatible ModelResponse
+    choice = response.choices[0]
+    message = choice.message
+
+    # Convert tool calls to LLMToolCall format
+    _tu = None
+    if message.tool_calls:
+        _tu = []
+        for tool_call in message.tool_calls:
+            _tu.append({
+                "id": tool_call.id,
+                "type": tool_call.type,
+                "function": {
+                    "name": tool_call.function.name,
+                    "arguments": json.loads(tool_call.function.arguments),
+                },
+            })
+
+    llm_response = LLMResponse(
+        role=message.role,
+        raw_response=response,
+        content=message.content,
+        tool_calls=_tu,
+    )
+
+    if json_mode and message.content:
+        try:
+            json_content = json.loads(message.content)
+        except json.JSONDecodeError:
+            LOG.error(
+                "llm.json_decode_error",
+                content=message.content[:200],
+            )
+            json_content = None
+        llm_response.json_content = json_content
+
+    return llm_response

--- a/src/server/core/acontext_core/schema/config.py
+++ b/src/server/core/acontext_core/schema/config.py
@@ -21,7 +21,7 @@ class CoreConfig(BaseModel):
     llm_openai_default_header: Optional[Mapping[str, Any]] = None
     llm_openai_completion_kwargs: Mapping[str, Any] = {}
     llm_response_timeout: float = 60
-    llm_sdk: Literal["openai", "anthropic", "mock"] = "openai"
+    llm_sdk: Literal["openai", "anthropic", "litellm", "mock"] = "openai"
 
     llm_simple_model: str = "gpt-4.1"
 

--- a/src/server/core/pyproject.toml
+++ b/src/server/core/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.54.0",
     "opentelemetry-instrumentation-redis>=0.54.0",
     "httpx>=0.27.0",
+    "litellm>=1.72.0",
     "opentelemetry-instrumentation-httpx>=0.54.0",
     "opentelemetry-instrumentation-openai-v2>=2.0.0",
     "opentelemetry-instrumentation-anthropic>=0.35.0",

--- a/src/server/core/tests/llm/test_litellm_provider.py
+++ b/src/server/core/tests/llm/test_litellm_provider.py
@@ -1,0 +1,268 @@
+"""
+Tests for the litellm LLM provider.
+
+Validates that litellm_complete correctly:
+- Makes async completions and returns LLMResponse
+- Handles tool calls
+- Handles JSON mode
+- Raises on empty messages
+- Passes history messages through
+- Is registered in FACTORIES
+- Is accepted by CoreConfig
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pydantic import BaseModel
+
+from acontext_core.schema.llm import LLMResponse, LLMToolCall, LLMFunction
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock litellm responses
+# ---------------------------------------------------------------------------
+
+class MockFunction(BaseModel):
+    name: str
+    arguments: str
+
+
+class MockToolCall(BaseModel):
+    id: str
+    type: str = "function"
+    function: MockFunction
+
+
+class MockUsage(BaseModel):
+    prompt_tokens: int = 10
+    completion_tokens: int = 20
+    prompt_tokens_details: object = None
+
+
+class MockMessage(BaseModel):
+    role: str = "assistant"
+    content: str | None = None
+    tool_calls: list[MockToolCall] | None = None
+
+    def model_dump(self, **kwargs):
+        d = {"role": self.role, "content": self.content}
+        if self.tool_calls:
+            d["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in self.tool_calls
+            ]
+        return d
+
+
+class MockChoice(BaseModel):
+    message: MockMessage
+
+
+class MockModelResponse(BaseModel):
+    choices: list[MockChoice]
+    usage: MockUsage = MockUsage()
+
+
+def _make_text_response(content: str = "Hello!") -> MockModelResponse:
+    return MockModelResponse(
+        choices=[MockChoice(message=MockMessage(content=content))],
+    )
+
+
+def _make_tool_response() -> MockModelResponse:
+    return MockModelResponse(
+        choices=[
+            MockChoice(
+                message=MockMessage(
+                    content=None,
+                    tool_calls=[
+                        MockToolCall(
+                            id="call_abc123",
+                            function=MockFunction(
+                                name="get_weather",
+                                arguments=json.dumps({"location": "Tokyo"}),
+                            ),
+                        )
+                    ],
+                )
+            )
+        ],
+    )
+
+
+def _make_json_response(content: str) -> MockModelResponse:
+    return MockModelResponse(
+        choices=[MockChoice(message=MockMessage(content=content))],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmComplete:
+    @pytest.mark.asyncio
+    async def test_basic_completion(self):
+        """Basic text completion returns correct LLMResponse."""
+        mock_resp = _make_text_response("Hello from litellm!")
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp):
+            from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+            result = await litellm_complete(
+                prompt="Say hello",
+                model="openai/gpt-4.1-mini",
+                max_tokens=100,
+            )
+
+            assert isinstance(result, LLMResponse)
+            assert result.role == "assistant"
+            assert result.content == "Hello from litellm!"
+            assert result.tool_calls is None
+
+    @pytest.mark.asyncio
+    async def test_with_tools(self):
+        """Tool call completion returns correct tool_calls in LLMResponse."""
+        mock_resp = _make_tool_response()
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp):
+            from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather for a location",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+
+            result = await litellm_complete(
+                prompt="What's the weather in Tokyo?",
+                model="openai/gpt-4.1",
+                tools=tools,
+            )
+
+            assert result.content is None
+            assert result.tool_calls is not None
+            assert len(result.tool_calls) == 1
+            assert result.tool_calls[0].function.name == "get_weather"
+            assert result.tool_calls[0].function.arguments == {"location": "Tokyo"}
+            assert result.tool_calls[0].id == "call_abc123"
+
+    @pytest.mark.asyncio
+    async def test_json_mode(self):
+        """JSON mode sets response_format and parses json_content."""
+        json_str = json.dumps({"answer": 42, "unit": "celsius"})
+        mock_resp = _make_json_response(json_str)
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp) as mock_call:
+            from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+            result = await litellm_complete(
+                prompt="Return JSON",
+                model="openai/gpt-4.1",
+                json_mode=True,
+            )
+
+            assert result.json_content == {"answer": 42, "unit": "celsius"}
+            # Verify response_format was passed
+            call_kwargs = mock_call.call_args.kwargs
+            assert call_kwargs["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_json_mode_invalid_json(self):
+        """JSON mode with invalid JSON content sets json_content to None."""
+        mock_resp = _make_json_response("not valid json {{{")
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp):
+            from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+            result = await litellm_complete(
+                prompt="Return JSON",
+                model="openai/gpt-4.1",
+                json_mode=True,
+            )
+
+            assert result.content == "not valid json {{{"
+            assert result.json_content is None
+
+    @pytest.mark.asyncio
+    async def test_no_messages_raises(self):
+        """Raises ValueError when no messages provided."""
+        from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+        with pytest.raises(ValueError, match="No messages provided"):
+            await litellm_complete(model="openai/gpt-4.1")
+
+    @pytest.mark.asyncio
+    async def test_with_history_messages(self):
+        """History messages are correctly passed through."""
+        mock_resp = _make_text_response("I remember!")
+
+        with patch("litellm.acompletion", new_callable=AsyncMock, return_value=mock_resp) as mock_call:
+            from acontext_core.llm.complete.litellm_sdk import litellm_complete
+
+            history = [
+                {"role": "user", "content": "My name is Alice"},
+                {"role": "assistant", "content": "Hello Alice!"},
+            ]
+
+            result = await litellm_complete(
+                prompt="What's my name?",
+                model="openai/gpt-4.1",
+                system_prompt="You are helpful.",
+                history_messages=history,
+            )
+
+            call_kwargs = mock_call.call_args.kwargs
+            messages = call_kwargs["messages"]
+            # system + 2 history + 1 user prompt = 4
+            assert len(messages) == 4
+            assert messages[0] == {"role": "system", "content": "You are helpful."}
+            assert messages[1] == {"role": "user", "content": "My name is Alice"}
+            assert messages[2] == {"role": "assistant", "content": "Hello Alice!"}
+            assert messages[3] == {"role": "user", "content": "What's my name?"}
+
+
+class TestLitellmRegistration:
+    def test_registered_in_factories(self):
+        """litellm is registered in the FACTORIES mapping."""
+        from acontext_core.llm.complete import FACTORIES
+
+        assert "litellm" in FACTORIES
+
+    def test_config_accepts_litellm(self):
+        """CoreConfig accepts llm_sdk='litellm'."""
+        from acontext_core.schema.config import CoreConfig
+
+        config = CoreConfig(llm_api_key="test-key", llm_sdk="litellm")
+        assert config.llm_sdk == "litellm"
+
+    def test_config_still_accepts_openai(self):
+        """CoreConfig still accepts llm_sdk='openai' (backward compat)."""
+        from acontext_core.schema.config import CoreConfig
+
+        config = CoreConfig(llm_api_key="test-key", llm_sdk="openai")
+        assert config.llm_sdk == "openai"
+
+    def test_config_still_accepts_anthropic(self):
+        """CoreConfig still accepts llm_sdk='anthropic' (backward compat)."""
+        from acontext_core.schema.config import CoreConfig
+
+        config = CoreConfig(llm_api_key="test-key", llm_sdk="anthropic")
+        assert config.llm_sdk == "anthropic"


### PR DESCRIPTION
## Summary

Adds `litellm` as a new LLM provider option in `acontext-core`, enabling model-agnostic completions across 100+ providers (OpenAI, Anthropic, Gemini, Mistral, Cohere, Bedrock, Azure, Ollama, etc.) through a unified interface.

## Changes

### New file: `src/server/core/acontext_core/llm/complete/litellm_sdk.py`
- Implements `litellm_complete()` following the same interface as existing `openai_complete()` and `anthropic_complete()`
- Uses `litellm.acompletion()` for async completion
- Supports text completion, tool calling, and JSON mode
- Includes proper token usage tracking and telemetry integration

### Modified: `src/server/core/acontext_core/llm/complete/__init__.py`
- Registered `litellm` in the `FACTORIES` mapping
- Added `litellm` case to `response_to_sendable_message()` (uses OpenAI-compatible format)

### Modified: `src/server/core/acontext_core/schema/config.py`
- Added `"litellm"` to `llm_sdk` Literal type: `Literal["openai", "anthropic", "litellm", "mock"]`

### Modified: `src/server/core/pyproject.toml`
- Added `litellm>=1.72.0` dependency

### New file: `src/server/core/tests/llm/test_litellm_provider.py`
- 10 unit tests covering: basic completion, tool calls, JSON mode, error handling, history messages, factory registration, and config validation
- All tests use mocked `litellm.acompletion` (no real API calls)

## Backward Compatibility

- ✅ Existing `llm_sdk: "openai"` configurations continue to work unchanged
- ✅ Existing `llm_sdk: "anthropic"` configurations continue to work unchanged
- ✅ All 194 non-DB-dependent existing tests pass

## Usage

Set in config:
```yaml
llm_sdk: litellm
llm_simple_model: openai/gpt-4.1  # or anthropic/claude-sonnet-4-20250514, gemini/gemini-2.0-flash, etc.
llm_api_key: your-api-key
```

Fixes #91