### PR TITLE
fix(api): restore admin ProjectAuth for Dashboard token format

### DIFF
--- a/src/server/api/go/internal/middleware/auth_admin.go
+++ b/src/server/api/go/internal/middleware/auth_admin.go
@@ -1,16 +1,21 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	supabaseauth "github.com/supabase-community/auth-go"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
 
 	"github.com/memodb-io/Acontext/internal/config"
+	"github.com/memodb-io/Acontext/internal/modules/model"
 	"github.com/memodb-io/Acontext/internal/modules/serializer"
+	"github.com/memodb-io/Acontext/internal/pkg/utils/tokens"
 )
 
 // SupabaseAuth returns a middleware that authenticates requests using Supabase JWT tokens.
@@ -56,6 +61,79 @@ func SupabaseAuth(cfg *config.Config) gin.HandlerFunc {
 
 		// Set user in context for use in handlers
 		c.Set("user", user)
+		c.Next()
+	}
+}
+
+// AdminProjectAuth returns a middleware that authenticates requests using the Dashboard's
+// base64 JSON project token format (project_id + signature verified against ApiBearerToken).
+// This is used by the admin router to override the default ProjectAuth (which uses HMAC secret key lookup).
+func AdminProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, authSpan := otel.Tracer("middleware").Start(
+			c.Request.Context(),
+			"admin_project_auth",
+			trace.WithAttributes(attribute.String("middleware", "admin_project_auth")),
+		)
+
+		auth := c.GetHeader("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			authSpan.SetAttributes(attribute.Bool("authenticated", false))
+			authSpan.End()
+			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Unauthorized"))
+			return
+		}
+		raw := strings.TrimPrefix(auth, "Bearer ")
+
+		secret, ok := tokens.ParseToken(raw, cfg.Root.ProjectBearerTokenPrefix)
+		if !ok {
+			authSpan.SetAttributes(attribute.Bool("authenticated", false))
+			authSpan.End()
+			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Unauthorized"))
+			return
+		}
+
+		// Parse and verify project token (base64 JSON with signature)
+		tokenData, err := tokens.ParseAndVerifyProjectToken(secret, cfg.Root.ApiBearerToken)
+		if err != nil {
+			authSpan.End()
+			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Invalid token format"))
+			return
+		}
+		if !tokenData.Valid {
+			authSpan.End()
+			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Invalid token signature"))
+			return
+		}
+
+		// Look up project by ID
+		var project model.Project
+		if err := db.WithContext(c.Request.Context()).Where(&model.Project{ID: tokenData.ProjectID}).First(&project).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				authSpan.End()
+				c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Project not found"))
+				return
+			}
+			authSpan.RecordError(err)
+			authSpan.End()
+			c.AbortWithStatusJSON(http.StatusInternalServerError, serializer.DBErr("", err))
+			return
+		}
+
+		// Set project_id on HTTP span for telemetry filtering
+		httpSpan := trace.SpanFromContext(c.Request.Context())
+		if httpSpan.SpanContext().IsValid() {
+			httpSpan.SetAttributes(attribute.String("project_id", project.ID.String()))
+		}
+
+		authSpan.SetAttributes(
+			attribute.String("project_id", project.ID.String()),
+			attribute.Bool("authenticated", true),
+		)
+		authSpan.End()
+
+		c.Set("project", &project)
+		SetWideEventField(c, "project_id", project.ID.String())
 		c.Next()
 	}
 }

--- a/src/server/api/go/internal/pkg/utils/tokens/tokens.go
+++ b/src/server/api/go/internal/pkg/utils/tokens/tokens.go
@@ -3,8 +3,17 @@ package tokens
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
 	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 )
 
 func ParseToken(raw, prefix string) (secret string, ok bool) {
@@ -18,4 +27,117 @@ func HMAC256Hex(pepper, secret string) string {
 	m := hmac.New(sha256.New, []byte(pepper))
 	m.Write([]byte(secret))
 	return hex.EncodeToString(m.Sum(nil)) // 64 hex chars
+}
+
+// ProjectTokenData represents the parsed project token data
+type ProjectTokenData struct {
+	ProjectID uuid.UUID
+	Valid     bool
+}
+
+// ParseAndVerifyProjectToken parses a base64-encoded JSON token and verifies its signature.
+// The token should be a base64-encoded JSON containing:
+//   - signature: the signature (base64 of sorted kv pairs + apiBearerToken)
+//   - project_id: the project UUID
+//   - other key-value pairs (sorted by key, concatenated as key+value, then base64 encoded with apiBearerToken)
+func ParseAndVerifyProjectToken(secret, apiBearerToken string) (*ProjectTokenData, error) {
+	// Decode base64 to get JSON
+	jsonBytes, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64: %w", err)
+	}
+
+	// Parse JSON
+	var tokenData map[string]any
+	if err := sonic.Unmarshal(jsonBytes, &tokenData); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	// Extract required fields
+	signatureValue, ok := tokenData["signature"].(string)
+	if !ok || signatureValue == "" {
+		return nil, errors.New("missing or invalid signature field")
+	}
+
+	projectIDStr, ok := tokenData["project_id"].(string)
+	if !ok || projectIDStr == "" {
+		return nil, errors.New("missing or invalid project_id field")
+	}
+
+	projectID, err := uuid.Parse(projectIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid project_id format: %w", err)
+	}
+
+	// Extract fields (excluding signature), sort by key, and concatenate
+	type kvPair struct {
+		key   string
+		value string
+	}
+	var pairs []kvPair
+	for key, value := range tokenData {
+		if key == "signature" {
+			continue
+		}
+		pairs = append(pairs, kvPair{key: key, value: stringifyTokenValue(value)})
+	}
+
+	// Sort by key
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].key < pairs[j].key
+	})
+
+	// Concatenate all pairs (key+value)
+	var parts []string
+	for _, pair := range pairs {
+		parts = append(parts, pair.key+pair.value)
+	}
+	concatenated := strings.Join(parts, "")
+
+	// Add apiBearerToken
+	signatureInput := concatenated + apiBearerToken
+
+	// Base64 encode
+	expectedSignature := base64.StdEncoding.EncodeToString([]byte(signatureInput))
+
+	// Verify token matches
+	valid := expectedSignature == signatureValue
+
+	return &ProjectTokenData{
+		ProjectID: projectID,
+		Valid:     valid,
+	}, nil
+}
+
+func stringifyTokenValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return t
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// JSON numbers decode into float64 for map[string]any
+		if !math.IsNaN(t) && !math.IsInf(t, 0) && math.Trunc(t) == t {
+			if t >= math.MinInt64 && t <= math.MaxInt64 {
+				return strconv.FormatInt(int64(t), 10)
+			}
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case float32:
+		f := float64(t)
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case uint64:
+		return strconv.FormatUint(t, 10)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }

--- a/src/server/api/go/internal/router/router.go
+++ b/src/server/api/go/internal/router/router.go
@@ -30,6 +30,7 @@ type RouterDeps struct {
 	LearningSpaceHandler *handler.LearningSpaceHandler
 	SessionEventHandler  *handler.SessionEventHandler
 	ProjectHandler       *handler.ProjectHandler
+	ProjectAuthOverride  gin.HandlerFunc // If set, used instead of default ProjectAuth for /api/v1
 }
 
 func NewRouter(d RouterDeps) *gin.Engine {
@@ -59,7 +60,11 @@ func NewRouter(d RouterDeps) *gin.Engine {
 
 	v1 := r.Group("/api/v1")
 	{
-		v1.Use(middleware.ProjectAuth(d.Config, d.DB))
+		projectAuth := d.ProjectAuthOverride
+		if projectAuth == nil {
+			projectAuth = middleware.ProjectAuth(d.Config, d.DB)
+		}
+		v1.Use(projectAuth)
 
 		// ping endpoint
 		v1.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, serializer.Response{Msg: "pong"}) })

--- a/src/server/api/go/internal/router/router_admin.go
+++ b/src/server/api/go/internal/router/router_admin.go
@@ -17,6 +17,9 @@ type AdminRouterDeps struct {
 // NewAdminRouter creates a Gin engine that includes all base routes
 // plus admin-specific route groups (/admin/v1 and /metrics/v1).
 func NewAdminRouter(d AdminRouterDeps) *gin.Engine {
+	// Override /api/v1 auth with admin's token format (base64 JSON with project_id + signature)
+	d.RouterDeps.ProjectAuthOverride = middleware.AdminProjectAuth(d.Config, d.DB)
+
 	// Start with the base router (includes /api/v1, /health, /swagger)
 	r := NewRouter(d.RouterDeps)
 


### PR DESCRIPTION
# Why we need this PR?

After merging the Acontext-admin fork into the main repo (#458), the admin router's `/api/v1` authentication was replaced by the SDK-oriented HMAC secret key lookup. The Dashboard generates a different token format (base64 JSON with `project_id` + `signature`), so **all Dashboard requests to `/api/v1/*` now fail with 401 Unauthorized**.

# Describe your solution

Add an `AdminProjectAuth` middleware that restores the old base64 JSON token verification logic, and a `ProjectAuthOverride` mechanism in `RouterDeps` so the admin router can override the default `ProjectAuth` without affecting the regular API server.

- **Regular API server** (`cmd/server`): continues using `ProjectAuth` with HMAC secret key lookup (SDK token format)
- **Admin API server** (`cmd/admin`): uses `AdminProjectAuth` with base64 JSON token verification (Dashboard token format)

# Implementation Tasks

- [x] Port `ParseAndVerifyProjectToken`, `ProjectTokenData`, and `stringifyTokenValue` back to `tokens/tokens.go`
- [x] Add `AdminProjectAuth` middleware to `auth_admin.go`
- [x] Add `ProjectAuthOverride` field to `RouterDeps` and use it in `NewRouter`
- [x] Set `ProjectAuthOverride` in `NewAdminRouter` to wire `AdminProjectAuth`

# Impact Areas

- [x] API Server

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.