### PR TITLE
fix(cli): remove duplicate error output and suppress usage on runtime errors

### DIFF
--- a/src/client/acontext-cli/cmd/dash_ping.go
+++ b/src/client/acontext-cli/cmd/dash_ping.go
@@ -16,7 +16,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// 1. Verify that we have a local key for the resolved project
 			if dashProject == "" {
-				return fmt.Errorf("no project selected\n\nTo fix this, run:\n  acontext dash projects select")
+				fmt.Println(tui.RenderWarning("No project selected"))
+				fmt.Println("\nTo fix this, run:\n  acontext dash projects select")
+				return nil
 			}
 
 			ks, err := auth.LoadKeyStore()
@@ -24,7 +26,9 @@ func init() {
 				return fmt.Errorf("failed to load credentials: %w", err)
 			}
 			if ks.Keys[dashProject] == "" {
-				return fmt.Errorf("no API key found in credentials.json for project %s\n\nTo fix this, run:\n  acontext dash projects select --project %s --api-key <sk-ac-...>\n\nThe API key can be found on the Acontext Dashboard:\n  https://dash.acontext.io", dashProject, dashProject)
+				fmt.Println(tui.RenderWarning(fmt.Sprintf("No API key found in credentials.json for project %s", dashProject)))
+				fmt.Printf("\nTo fix this, run:\n  acontext dash projects select --project %s --api-key <sk-ac-...>\n\nThe API key can be found on the Acontext Dashboard:\n  https://dash.acontext.io\n", dashProject)
+				return nil
 			}
 
 			// 2. Check API connectivity
@@ -36,7 +40,7 @@ func init() {
 			if err := client.Ping(cmd.Context()); err != nil {
 				fmt.Printf("Ping failed for project %s: %v\n", dashProject, err)
 				fmt.Printf("Fix with: acontext dash projects select --project %s --api-key <sk-ac-...>\n", dashProject)
-				return fmt.Errorf("ping failed")
+				return nil
 			}
 
 			fmt.Println(tui.RenderSuccess(fmt.Sprintf("Project %s is reachable. Setup complete.", dashProject)))

--- a/src/client/acontext-cli/cmd/login.go
+++ b/src/client/acontext-cli/cmd/login.go
@@ -197,7 +197,8 @@ func runLogout(cmd *cobra.Command, args []string) error {
 func runWhoami(cmd *cobra.Command, args []string) error {
 	af, err := auth.MustLoad()
 	if err != nil {
-		return err
+		fmt.Println("Not logged in — run 'acontext login' first")
+		return nil
 	}
 
 	// Validate token with Supabase and refresh if needed
@@ -206,7 +207,8 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 		// If session was auto-cleared (e.g. another device consumed the refresh token),
 		// show "not logged in" instead of the underlying error.
 		if !auth.IsLoggedIn() {
-			return fmt.Errorf("not logged in — run 'acontext login' first")
+			fmt.Println("Not logged in — run 'acontext login' first")
+			return nil
 		}
 		return err
 	}

--- a/src/client/acontext-cli/main.go
+++ b/src/client/acontext-cli/main.go
@@ -36,7 +36,6 @@ func main() {
 	}
 
 	if cmdErr := rootCmd.Execute(); cmdErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", cmdErr)
 		executedCmd, _, _ := rootCmd.Find(os.Args[1:])
 		if executedCmd == nil {
 			executedCmd = rootCmd
@@ -111,8 +110,9 @@ func buildCommandPath(cmd *cobra.Command) string {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "acontext",
-	Short: "Acontext CLI - Agent Skills as a Memory Layer",
+	Use:          "acontext",
+	SilenceUsage: true,
+	Short:        "Acontext CLI - Agent Skills as a Memory Layer",
 	Long: `Acontext CLI is a command-line tool for quickly creating Acontext projects.
 	
 It helps you:


### PR DESCRIPTION
# Why we need this PR?

Running `acontext whoami` (or `dash ping`) when not logged in prints the error message twice — once by Cobra automatically and once by manual `fmt.Fprintf` in `main()`. Additionally, runtime errors incorrectly show Usage/help text.

# Describe your solution

1. **Remove duplicate error print** — `main.go` had `fmt.Fprintf(os.Stderr, "Error: %v\n", cmdErr)` which duplicated Cobra's built-in error output. Removed it; Cobra handles the printing.
2. **Add `SilenceUsage: true`** on root command — runtime errors (e.g. API failures, not-logged-in) should not print Usage info. Usage is only useful for argument/syntax errors, which Cobra handles before `RunE`.
3. **`whoami` not-logged-in is informational, not an error** — `runWhoami` now prints the message and returns `nil` instead of returning an error. This matches `runLogout`'s pattern which already does the same.
4. **`dash ping` state checks** — "no project selected", "no API key", and ping failure now print info and return `nil` instead of returning errors. The ping failure case was double-printing (diagnostic output + separate error return).

# Implementation Tasks
- [x] Add `SilenceUsage: true` to rootCmd in `main.go`
- [x] Remove manual `fmt.Fprintf(os.Stderr, ...)` error print in `main()`
- [x] Change `runWhoami` to treat not-logged-in as info output
- [x] Fix `dash ping` double-print and state-check error returns

# Impact Areas
- [x] CLI Tool

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)