### PR TITLE
perf(api): buffer asset_references writes via Redis to eliminate row-lock contention

### DIFF
--- a/src/server/api/go/cmd/server/main.go
+++ b/src/server/api/go/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/memodb-io/Acontext/internal/bootstrap"
 	"github.com/memodb-io/Acontext/internal/config"
+	"github.com/memodb-io/Acontext/internal/infra/assetrefwriter"
 	"github.com/memodb-io/Acontext/internal/infra/cache"
 	dbpkg "github.com/memodb-io/Acontext/internal/infra/db"
 	"github.com/memodb-io/Acontext/internal/modules/handler"
@@ -138,5 +139,13 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Sugar().Errorw("server shutdown", "err", err)
 	}
+
+	// Flush buffered asset reference writes before exit
+	if writer := do.MustInvoke[*assetrefwriter.AssetRefWriter](inj); writer != nil {
+		if err := writer.Close(ctx); err != nil {
+			log.Sugar().Errorw("asset ref writer shutdown", "err", err)
+		}
+	}
+
 	log.Sugar().Info("server exited")
 }

--- a/src/server/api/go/internal/bootstrap/container.go
+++ b/src/server/api/go/internal/bootstrap/container.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/memodb-io/Acontext/configs"
 	"github.com/memodb-io/Acontext/internal/config"
+	"github.com/memodb-io/Acontext/internal/infra/assetrefwriter"
 	"github.com/memodb-io/Acontext/internal/infra/blob"
 	"github.com/memodb-io/Acontext/internal/infra/cache"
 	"github.com/memodb-io/Acontext/internal/infra/db"
@@ -215,6 +216,27 @@ func BuildContainer() *do.Injector {
 			do.MustInvoke[*blob.S3Deps](i),
 		), nil
 	})
+
+	// AssetRefWriter — buffers asset reference increments in Redis for async batch flush
+	do.Provide(inj, func(i *do.Injector) (*assetrefwriter.AssetRefWriter, error) {
+		cfg := do.MustInvoke[*config.Config](i)
+		if !cfg.AssetRefWriter.Enabled {
+			return nil, nil
+		}
+		interval := time.Duration(cfg.AssetRefWriter.FlushIntervalMs) * time.Millisecond
+		if interval <= 0 {
+			interval = time.Second
+		}
+		w := assetrefwriter.New(
+			do.MustInvoke[*redis.Client](i),
+			do.MustInvoke[repo.AssetReferenceRepo](i),
+			do.MustInvoke[*zap.Logger](i),
+			assetrefwriter.WithFlushInterval(interval),
+		)
+		w.Start()
+		return w, nil
+	})
+
 	do.Provide(inj, func(i *do.Injector) (repo.SessionRepo, error) {
 		return repo.NewSessionRepo(
 			do.MustInvoke[*gorm.DB](i),
@@ -268,6 +290,7 @@ func BuildContainer() *do.Injector {
 			do.MustInvoke[repo.SessionRepo](i),
 			do.MustInvoke[repo.SessionEventRepo](i),
 			do.MustInvoke[repo.AssetReferenceRepo](i),
+			do.MustInvoke[*assetrefwriter.AssetRefWriter](i),
 			do.MustInvoke[*zap.Logger](i),
 			do.MustInvoke[*blob.S3Deps](i),
 			do.MustInvoke[*mq.Publisher](i),

--- a/src/server/api/go/internal/config/config.go
+++ b/src/server/api/go/internal/config/config.go
@@ -101,19 +101,25 @@ type ArtifactCfg struct {
 	MaxUploadSizeBytes int64 // Maximum file upload size in bytes
 }
 
+type AssetRefWriterCfg struct {
+	Enabled         bool // Enable async buffered writes for asset references (default true)
+	FlushIntervalMs int  // Flush interval in milliseconds (default 1000)
+}
+
 type Config struct {
-	App       AppCfg
-	Root      RootCfg
-	Log       LogCfg
-	Database  DBCfg
-	Redis     RedisCfg
-	RabbitMQ  MQCfg
-	S3        S3Cfg
-	Core      CoreCfg
-	Metrics   MetricsCfg
-	Telemetry TelemetryCfg
-	Supabase  SupabaseCfg
-	Artifact  ArtifactCfg
+	App            AppCfg
+	Root           RootCfg
+	Log            LogCfg
+	Database       DBCfg
+	Redis          RedisCfg
+	RabbitMQ       MQCfg
+	S3             S3Cfg
+	Core           CoreCfg
+	Metrics        MetricsCfg
+	Telemetry      TelemetryCfg
+	Supabase       SupabaseCfg
+	Artifact       ArtifactCfg
+	AssetRefWriter AssetRefWriterCfg
 }
 
 func setDefaults(v *viper.Viper) {
@@ -151,6 +157,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("supabase.apiKey", "")
 	v.SetDefault("supabase.authURL", "")
 	v.SetDefault("artifact.maxUploadSizeBytes", 16777216) // Default 16MB (16 * 1024 * 1024 bytes)
+	v.SetDefault("assetRefWriter.enabled", true)
+	v.SetDefault("assetRefWriter.flushIntervalMs", 1000)
 }
 
 func Load() (*Config, error) {

--- a/src/server/api/go/internal/infra/assetrefwriter/writer.go
+++ b/src/server/api/go/internal/infra/assetrefwriter/writer.go
@@ -1,0 +1,309 @@
+package assetrefwriter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/memodb-io/Acontext/internal/modules/model"
+	"github.com/memodb-io/Acontext/internal/modules/repo"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+const (
+	// Redis key prefixes
+	pendingKeyPrefix = "assetref:pending:"  // Hash: field=sha256, value=count
+	dirtySetKey      = "assetref:dirty_projects"
+	metaKeyPrefix    = "assetref:meta:"     // String: JSON-encoded Asset
+
+	// Default TTL for pending and meta keys (safety net)
+	defaultKeyTTL = 24 * time.Hour
+)
+
+// AssetRefWriter buffers asset reference increments in Redis and periodically
+// flushes them to the database in batches. This eliminates PostgreSQL row-level
+// lock contention when many concurrent requests write to the same project.
+type AssetRefWriter struct {
+	redis    *redis.Client
+	repo     repo.AssetReferenceRepo
+	log      *zap.Logger
+	interval time.Duration
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// Option configures the AssetRefWriter.
+type Option func(*AssetRefWriter)
+
+// WithFlushInterval sets the flush interval.
+func WithFlushInterval(d time.Duration) Option {
+	return func(w *AssetRefWriter) {
+		w.interval = d
+	}
+}
+
+// New creates a new AssetRefWriter.
+func New(rdb *redis.Client, assetRepo repo.AssetReferenceRepo, log *zap.Logger, opts ...Option) *AssetRefWriter {
+	w := &AssetRefWriter{
+		redis:    rdb,
+		repo:     assetRepo,
+		log:      log.Named("asset-ref-writer"),
+		interval: time.Second,
+		stopCh:   make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(w)
+	}
+	return w
+}
+
+// Start launches the background flush goroutine.
+func (w *AssetRefWriter) Start() {
+	w.wg.Add(1)
+	go w.loop()
+}
+
+// Enqueue buffers asset reference increments in Redis.
+// This is the hot-path replacement for synchronous BatchIncrementAssetRefs.
+func (w *AssetRefWriter) Enqueue(ctx context.Context, projectID uuid.UUID, assets []model.Asset) error {
+	if len(assets) == 0 {
+		return nil
+	}
+
+	// Group by sha256 to coalesce duplicates within one call
+	type agg struct {
+		asset model.Asset
+		count int64
+	}
+	grouped := make(map[string]*agg)
+	for _, a := range assets {
+		if a.SHA256 == "" {
+			continue
+		}
+		if g, ok := grouped[a.SHA256]; ok {
+			g.count++
+		} else {
+			grouped[a.SHA256] = &agg{asset: a, count: 1}
+		}
+	}
+	if len(grouped) == 0 {
+		return nil
+	}
+
+	pid := projectID.String()
+	pendingKey := pendingKeyPrefix + pid
+
+	pipe := w.redis.Pipeline()
+
+	for sha256, g := range grouped {
+		// Increment pending count
+		pipe.HIncrBy(ctx, pendingKey, sha256, g.count)
+
+		// Cache asset metadata (SETNX — only set if not exists)
+		metaKey := metaKeyPrefix + pid + ":" + sha256
+		metaJSON, err := json.Marshal(g.asset)
+		if err != nil {
+			w.log.Error("marshal asset meta", zap.Error(err))
+			continue
+		}
+		pipe.SetNX(ctx, metaKey, metaJSON, defaultKeyTTL)
+	}
+
+	// Mark project as dirty
+	pipe.SAdd(ctx, dirtySetKey, pid)
+
+	// Set TTL on pending key as safety net
+	pipe.Expire(ctx, pendingKey, defaultKeyTTL)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		w.log.Error("enqueue asset refs to redis", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (w *AssetRefWriter) loop() {
+	defer w.wg.Done()
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			w.flush()
+		case <-w.stopCh:
+			// Final flush before exit
+			w.flush()
+			return
+		}
+	}
+}
+
+// flush pops dirty projects and flushes each one.
+func (w *AssetRefWriter) flush() {
+	ctx := context.Background()
+
+	for {
+		// SPOP one project at a time to avoid holding too many in memory
+		pid, err := w.redis.SPop(ctx, dirtySetKey).Result()
+		if err == redis.Nil {
+			return // no more dirty projects
+		}
+		if err != nil {
+			w.log.Error("spop dirty projects", zap.Error(err))
+			return
+		}
+
+		projectID, err := uuid.Parse(pid)
+		if err != nil {
+			w.log.Error("parse project id from dirty set", zap.String("pid", pid), zap.Error(err))
+			continue
+		}
+
+		if err := w.flushProject(ctx, projectID); err != nil {
+			w.log.Error("flush project", zap.String("project_id", pid), zap.Error(err))
+			// Re-add to dirty set so it gets retried next tick
+			w.redis.SAdd(ctx, dirtySetKey, pid)
+		}
+	}
+}
+
+// flushProject reads pending counts from Redis, clears them, and writes to DB.
+// On DB failure, it restores the counts back to Redis.
+func (w *AssetRefWriter) flushProject(ctx context.Context, projectID uuid.UUID) error {
+	pid := projectID.String()
+	pendingKey := pendingKeyPrefix + pid
+
+	// Read all pending sha256 -> count
+	pending, err := w.redis.HGetAll(ctx, pendingKey).Result()
+	if err != nil {
+		return fmt.Errorf("hgetall %s: %w", pendingKey, err)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	// Parse counts and collect fields to delete
+	type entry struct {
+		sha256 string
+		count  int64
+	}
+	entries := make([]entry, 0, len(pending))
+	fields := make([]string, 0, len(pending))
+	for sha256, countStr := range pending {
+		count, err := strconv.ParseInt(countStr, 10, 64)
+		if err != nil {
+			w.log.Error("parse count", zap.String("sha256", sha256), zap.String("count", countStr), zap.Error(err))
+			continue
+		}
+		entries = append(entries, entry{sha256: sha256, count: count})
+		fields = append(fields, sha256)
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Atomically delete the fields we're about to flush.
+	// New HINCRBY calls that arrive between HGETALL and HDEL will create new fields
+	// or increment after our delete — they'll be picked up on the next flush cycle.
+	w.redis.HDel(ctx, pendingKey, fields...)
+
+	// Load asset metadata and build the asset slice
+	assets := make([]model.Asset, 0, len(entries))
+	countMap := make(map[string]int64, len(entries)) // sha256 -> total count for batch
+	for _, e := range entries {
+		metaKey := metaKeyPrefix + pid + ":" + e.sha256
+		metaJSON, err := w.redis.Get(ctx, metaKey).Bytes()
+		if err != nil {
+			w.log.Error("get asset meta", zap.String("key", metaKey), zap.Error(err))
+			// Restore count to Redis since we can't flush without metadata
+			w.redis.HIncrBy(ctx, pendingKey, e.sha256, e.count)
+			w.redis.SAdd(ctx, dirtySetKey, pid)
+			continue
+		}
+
+		var asset model.Asset
+		if err := json.Unmarshal(metaJSON, &asset); err != nil {
+			w.log.Error("unmarshal asset meta", zap.Error(err))
+			w.redis.HIncrBy(ctx, pendingKey, e.sha256, e.count)
+			w.redis.SAdd(ctx, dirtySetKey, pid)
+			continue
+		}
+
+		// BatchIncrementAssetRefs groups by sha256 and uses EXCLUDED.ref_count,
+		// so we add the asset `count` times to leverage the existing coalescing logic.
+		// However, it's more efficient to add once with the correct count directly.
+		// We'll add a single asset and set the count via a wrapper.
+		assets = append(assets, asset)
+		countMap[asset.SHA256] = e.count
+	}
+
+	if len(assets) == 0 {
+		return nil
+	}
+
+	// Build the expanded asset list for BatchIncrementAssetRefs.
+	// The repo already coalesces by sha256, so we expand to count occurrences.
+	expandedAssets := make([]model.Asset, 0, len(assets))
+	for _, a := range assets {
+		count := countMap[a.SHA256]
+		for i := int64(0); i < count; i++ {
+			expandedAssets = append(expandedAssets, a)
+		}
+	}
+
+	// Write to DB
+	if err := w.repo.BatchIncrementAssetRefs(ctx, projectID, expandedAssets); err != nil {
+		w.log.Error("batch increment asset refs", zap.String("project_id", pid), zap.Int("assets", len(assets)), zap.Error(err))
+		// Restore counts to Redis for retry
+		pipe := w.redis.Pipeline()
+		for _, e := range entries {
+			pipe.HIncrBy(ctx, pendingKey, e.sha256, e.count)
+		}
+		pipe.SAdd(ctx, dirtySetKey, pid)
+		pipe.Exec(ctx)
+		return err
+	}
+
+	// Clean up metadata keys after successful flush
+	pipe := w.redis.Pipeline()
+	for _, a := range assets {
+		metaKey := metaKeyPrefix + pid + ":" + a.SHA256
+		pipe.Del(ctx, metaKey)
+	}
+	pipe.Exec(ctx)
+
+	w.log.Debug("flushed asset refs",
+		zap.String("project_id", pid),
+		zap.Int("unique_assets", len(assets)),
+		zap.Int("total_refs", len(expandedAssets)),
+	)
+
+	return nil
+}
+
+// Close stops the background goroutine and flushes remaining data.
+// It respects the context deadline for the final flush.
+func (w *AssetRefWriter) Close(ctx context.Context) error {
+	close(w.stopCh)
+
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/src/server/api/go/internal/infra/assetrefwriter/writer_test.go
+++ b/src/server/api/go/internal/infra/assetrefwriter/writer_test.go
@@ -1,0 +1,335 @@
+package assetrefwriter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/memodb-io/Acontext/internal/modules/model"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mockAssetReferenceRepo tracks calls to BatchIncrementAssetRefs.
+type mockAssetReferenceRepo struct {
+	calls     []batchCall
+	failNext  bool
+	failCount int
+}
+
+type batchCall struct {
+	ProjectID uuid.UUID
+	Assets    []model.Asset
+}
+
+func (m *mockAssetReferenceRepo) IncrementAssetRef(_ context.Context, projectID uuid.UUID, asset model.Asset) error {
+	return nil
+}
+
+func (m *mockAssetReferenceRepo) DecrementAssetRef(_ context.Context, projectID uuid.UUID, asset model.Asset) error {
+	return nil
+}
+
+func (m *mockAssetReferenceRepo) BatchIncrementAssetRefs(_ context.Context, projectID uuid.UUID, assets []model.Asset) error {
+	if m.failNext {
+		m.failCount++
+		if m.failCount <= 1 {
+			return fmt.Errorf("simulated DB error")
+		}
+		// Succeed on retry
+		m.failNext = false
+	}
+	m.calls = append(m.calls, batchCall{ProjectID: projectID, Assets: append([]model.Asset{}, assets...)})
+	return nil
+}
+
+func (m *mockAssetReferenceRepo) BatchDecrementAssetRefs(_ context.Context, projectID uuid.UUID, assets []model.Asset) error {
+	return nil
+}
+
+func newTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	rdb := redis.NewClient(&redis.Options{
+		Addr: "127.0.0.1:16379",
+		DB:   15, // Use DB 15 for tests to avoid collisions
+	})
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("Redis not available at 127.0.0.1:16379: %v", err)
+	}
+	// Clean test keys
+	t.Cleanup(func() {
+		keys, _ := rdb.Keys(ctx, "assetref:*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+	return rdb
+}
+
+func TestEnqueue_WritesToRedis(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour)) // long interval so no auto-flush
+	w.Start()
+	defer w.Close(ctx)
+
+	projectID := uuid.New()
+	assets := []model.Asset{
+		{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b", MIME: "application/json", SizeB: 100},
+		{SHA256: "bbb", S3Key: "s3/bbb", Bucket: "b", MIME: "application/json", SizeB: 200},
+	}
+
+	err := w.Enqueue(ctx, projectID, assets)
+	require.NoError(t, err)
+
+	// Verify pending hash
+	pendingKey := pendingKeyPrefix + projectID.String()
+	val, err := rdb.HGet(ctx, pendingKey, "aaa").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "1", val)
+
+	val, err = rdb.HGet(ctx, pendingKey, "bbb").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "1", val)
+
+	// Verify dirty set
+	isMember, err := rdb.SIsMember(ctx, dirtySetKey, projectID.String()).Result()
+	require.NoError(t, err)
+	assert.True(t, isMember)
+
+	// Verify metadata cached
+	metaKey := metaKeyPrefix + projectID.String() + ":aaa"
+	metaJSON, err := rdb.Get(ctx, metaKey).Bytes()
+	require.NoError(t, err)
+	var meta model.Asset
+	require.NoError(t, json.Unmarshal(metaJSON, &meta))
+	assert.Equal(t, "aaa", meta.SHA256)
+	assert.Equal(t, "s3/aaa", meta.S3Key)
+}
+
+func TestEnqueue_CoalescesDuplicates(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour))
+	w.Start()
+	defer w.Close(ctx)
+
+	projectID := uuid.New()
+	asset := model.Asset{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b"}
+
+	// Enqueue same asset 5 times in one call
+	assets := []model.Asset{asset, asset, asset, asset, asset}
+	err := w.Enqueue(ctx, projectID, assets)
+	require.NoError(t, err)
+
+	pendingKey := pendingKeyPrefix + projectID.String()
+	val, err := rdb.HGet(ctx, pendingKey, "aaa").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "5", val)
+}
+
+func TestEnqueue_MultipleCallsAccumulate(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour))
+	w.Start()
+	defer w.Close(ctx)
+
+	projectID := uuid.New()
+	asset := model.Asset{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b"}
+
+	// Multiple separate Enqueue calls
+	for i := 0; i < 10; i++ {
+		require.NoError(t, w.Enqueue(ctx, projectID, []model.Asset{asset}))
+	}
+
+	pendingKey := pendingKeyPrefix + projectID.String()
+	val, err := rdb.HGet(ctx, pendingKey, "aaa").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "10", val)
+}
+
+func TestFlush_CoalescesAndWritesToDB(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(100*time.Millisecond))
+	w.Start()
+
+	projectID := uuid.New()
+	asset := model.Asset{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b", MIME: "application/json", SizeB: 100}
+
+	// Enqueue 100 times
+	for i := 0; i < 100; i++ {
+		require.NoError(t, w.Enqueue(ctx, projectID, []model.Asset{asset}))
+	}
+
+	// Wait for flush
+	time.Sleep(300 * time.Millisecond)
+	w.Close(ctx)
+
+	// Should have exactly 1 DB call
+	require.Len(t, mockRepo.calls, 1)
+	assert.Equal(t, projectID, mockRepo.calls[0].ProjectID)
+
+	// The expanded assets should sum to 100
+	assert.Len(t, mockRepo.calls[0].Assets, 100)
+}
+
+func TestClose_FlushesRemainingData(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour)) // long interval
+	w.Start()
+
+	projectID := uuid.New()
+	assets := []model.Asset{
+		{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b", MIME: "application/json", SizeB: 100},
+	}
+
+	require.NoError(t, w.Enqueue(ctx, projectID, assets))
+
+	// Close should trigger final flush
+	err := w.Close(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, mockRepo.calls, 1)
+	assert.Equal(t, projectID, mockRepo.calls[0].ProjectID)
+}
+
+func TestFlush_DBFailure_RestoresToRedis(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{failNext: true}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(100*time.Millisecond))
+	w.Start()
+
+	projectID := uuid.New()
+	asset := model.Asset{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b", MIME: "application/json", SizeB: 100}
+
+	require.NoError(t, w.Enqueue(ctx, projectID, []model.Asset{asset, asset, asset}))
+
+	// Wait for first flush attempt (will fail) + retry (will succeed)
+	time.Sleep(500 * time.Millisecond)
+	w.Close(ctx)
+
+	// After retry, the data should have been written to DB
+	require.GreaterOrEqual(t, len(mockRepo.calls), 1)
+
+	// Verify pending hash is cleaned up
+	pendingKey := pendingKeyPrefix + projectID.String()
+	count, err := rdb.HLen(ctx, pendingKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestEnqueue_EmptyAssets_NoOp(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log)
+
+	projectID := uuid.New()
+	err := w.Enqueue(ctx, projectID, []model.Asset{})
+	assert.NoError(t, err)
+
+	err = w.Enqueue(ctx, projectID, nil)
+	assert.NoError(t, err)
+
+	// No dirty projects
+	count, err := rdb.SCard(ctx, dirtySetKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestFlush_MultipleProjects(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour))
+	w.Start()
+
+	p1 := uuid.New()
+	p2 := uuid.New()
+	asset := model.Asset{SHA256: "aaa", S3Key: "s3/aaa", Bucket: "b", MIME: "application/json", SizeB: 100}
+
+	require.NoError(t, w.Enqueue(ctx, p1, []model.Asset{asset}))
+	require.NoError(t, w.Enqueue(ctx, p2, []model.Asset{asset, asset}))
+
+	// Close triggers final flush
+	w.Close(ctx)
+
+	// Should have 2 DB calls (one per project)
+	require.Len(t, mockRepo.calls, 2)
+
+	// Verify each project got the right count
+	countByProject := make(map[uuid.UUID]int)
+	for _, c := range mockRepo.calls {
+		countByProject[c.ProjectID] = len(c.Assets)
+	}
+	assert.Equal(t, 1, countByProject[p1])
+	assert.Equal(t, 2, countByProject[p2])
+}
+
+func TestMetadata_SETNXIdempotent(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	mockRepo := &mockAssetReferenceRepo{}
+	log := zap.NewNop()
+
+	w := New(rdb, mockRepo, log, WithFlushInterval(time.Hour))
+	w.Start()
+	defer w.Close(ctx)
+
+	projectID := uuid.New()
+
+	// First enqueue with S3Key "first"
+	asset1 := model.Asset{SHA256: "aaa", S3Key: "s3/first", Bucket: "b"}
+	require.NoError(t, w.Enqueue(ctx, projectID, []model.Asset{asset1}))
+
+	// Second enqueue with different S3Key — metadata should NOT be overwritten
+	asset2 := model.Asset{SHA256: "aaa", S3Key: "s3/second", Bucket: "b"}
+	require.NoError(t, w.Enqueue(ctx, projectID, []model.Asset{asset2}))
+
+	metaKey := metaKeyPrefix + projectID.String() + ":aaa"
+	metaJSON, err := rdb.Get(ctx, metaKey).Bytes()
+	require.NoError(t, err)
+	var meta model.Asset
+	require.NoError(t, json.Unmarshal(metaJSON, &meta))
+	assert.Equal(t, "s3/first", meta.S3Key, "SETNX should preserve the first metadata")
+
+	// But the count should be accumulated
+	pendingKey := pendingKeyPrefix + projectID.String()
+	val, err := rdb.HGet(ctx, pendingKey, "aaa").Result()
+	require.NoError(t, err)
+	count, _ := strconv.Atoi(val)
+	assert.Equal(t, 2, count)
+}

--- a/src/server/api/go/internal/modules/service/session.go
+++ b/src/server/api/go/internal/modules/service/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/memodb-io/Acontext/internal/config"
+	"github.com/memodb-io/Acontext/internal/infra/assetrefwriter"
 	"github.com/memodb-io/Acontext/internal/infra/blob"
 	mq "github.com/memodb-io/Acontext/internal/infra/queue"
 	"github.com/memodb-io/Acontext/internal/modules/model"
@@ -53,6 +54,7 @@ type sessionService struct {
 	sessionRepo        repo.SessionRepo
 	sessionEventRepo   repo.SessionEventRepo
 	assetReferenceRepo repo.AssetReferenceRepo
+	assetRefWriter     *assetrefwriter.AssetRefWriter
 	log                *zap.Logger
 	s3                 *blob.S3Deps
 	publisher          *mq.Publisher
@@ -67,11 +69,12 @@ const (
 	defaultPartsCacheTTL = time.Hour
 )
 
-func NewSessionService(sessionRepo repo.SessionRepo, sessionEventRepo repo.SessionEventRepo, assetReferenceRepo repo.AssetReferenceRepo, log *zap.Logger, s3 *blob.S3Deps, publisher *mq.Publisher, cfg *config.Config, redis *redis.Client) SessionService {
+func NewSessionService(sessionRepo repo.SessionRepo, sessionEventRepo repo.SessionEventRepo, assetReferenceRepo repo.AssetReferenceRepo, assetRefWriter *assetrefwriter.AssetRefWriter, log *zap.Logger, s3 *blob.S3Deps, publisher *mq.Publisher, cfg *config.Config, redis *redis.Client) SessionService {
 	return &sessionService{
 		sessionRepo:        sessionRepo,
 		sessionEventRepo:   sessionEventRepo,
 		assetReferenceRepo: assetReferenceRepo,
+		assetRefWriter:     assetRefWriter,
 		log:                log,
 		s3:                 s3,
 		publisher:          publisher,
@@ -342,9 +345,19 @@ func (s *sessionService) StoreMessage(ctx context.Context, in StoreMessageInput)
 
 	uploadedAssets = append(uploadedAssets, *asset)
 
-	// Batch increment all asset references in a single DB round-trip
-	if err := s.assetReferenceRepo.BatchIncrementAssetRefs(ctx, in.ProjectID, uploadedAssets); err != nil {
-		return nil, fmt.Errorf("batch increment asset references: %w", err)
+	// Buffer asset reference increments in Redis for async batch flush.
+	// This avoids PostgreSQL row-level lock contention under high concurrency.
+	if s.assetRefWriter != nil {
+		if err := s.assetRefWriter.Enqueue(ctx, in.ProjectID, uploadedAssets); err != nil {
+			s.log.Warn("async asset ref enqueue failed, falling back to sync", zap.Error(err))
+			if err := s.assetReferenceRepo.BatchIncrementAssetRefs(ctx, in.ProjectID, uploadedAssets); err != nil {
+				return nil, fmt.Errorf("batch increment asset references: %w", err)
+			}
+		}
+	} else {
+		if err := s.assetReferenceRepo.BatchIncrementAssetRefs(ctx, in.ProjectID, uploadedAssets); err != nil {
+			return nil, fmt.Errorf("batch increment asset references: %w", err)
+		}
 	}
 
 	// Cache parts data in Redis after successful S3 upload

--- a/src/server/api/go/internal/modules/service/session_test.go
+++ b/src/server/api/go/internal/modules/service/session_test.go
@@ -240,7 +240,7 @@ func TestSessionService_Create(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			err := service.Create(ctx, tt.session)
 
@@ -318,7 +318,7 @@ func TestSessionService_Delete(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			err := service.Delete(ctx, tt.projectID, tt.sessionID)
 
@@ -403,7 +403,7 @@ func TestSessionService_GetByID(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			result, err := service.GetByID(ctx, tt.session)
 
@@ -475,7 +475,7 @@ func TestSessionService_UpdateByID(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			err := service.UpdateByID(ctx, tt.session)
 
@@ -566,7 +566,7 @@ func TestSessionService_List(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			result, err := service.List(ctx, tt.input)
 
@@ -1085,7 +1085,7 @@ func TestSessionService_StoreMessage_GeminiFunctionResponse(t *testing.T) {
 			var service SessionService
 			if tt.wantErr {
 				// For error cases, we can use nil S3 since errors happen before S3 upload
-				service = NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+				service = NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 			} else {
 				// For success cases, we need to skip this test or use integration test
 				// For now, we'll mark these as skipped or use a workaround
@@ -1245,7 +1245,7 @@ func TestSessionService_GetMessages(t *testing.T) {
 				},
 			}
 			// Note: blob is nil in test, so GetMessages will skip DownloadJSON and PresignGet
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			result, err := service.GetMessages(ctx, tt.input)
 
@@ -1405,7 +1405,7 @@ func TestSessionService_GetMessages_SortOrder(t *testing.T) {
 					},
 				},
 			}
-			service := NewSessionService(repo, nil, mockAssetRefRepo, logger, nil, nil, cfg, nil)
+			service := NewSessionService(repo, nil, mockAssetRefRepo, nil, logger, nil, nil, cfg, nil)
 
 			result, err := service.GetMessages(ctx, tt.input)
 


### PR DESCRIPTION
# Why we need this PR?

Under high concurrency (50+ concurrent learn sessions writing to the same project), the `asset_references` table suffers severe PostgreSQL row-level lock contention:
- 348 slow queries (avg 316ms, P99 889ms, max 1.8s)
- 132 S3 PutObject context canceled errors
- API pod graceful shutdown timeout → 504 Gateway Timeout for clients

Root cause: `StoreMessage` synchronously calls `BatchIncrementAssetRefs` on the hot path. The `INSERT ... ON CONFLICT DO UPDATE` query acquires exclusive row locks on `(project_id, sha256)`, and 50 concurrent writers create lock-wait chains that cascade into timeouts.

# Describe your solution

Replace the synchronous DB upsert with a stateless Redis-buffered async writer:

**Hot path (write):** `StoreMessage` no longer writes to DB directly. Instead it uses Redis `HINCRBY` + `SADD` (µs-level latency) to buffer pending ref-count increments.

**Background flush (every 1s):**
1. `SPOP` from dirty projects set
2. `HGETALL` + `HDEL` to read and clear pending counts atomically
3. Call `BatchIncrementAssetRefs` once per project to write coalesced batch to DB
4. On DB failure, `HINCRBY` restores counts back to Redis for automatic retry

**Key properties:**
- **Stateless:** Any pod can flush any project's pending data. Pod crash/restart loses at most 1s of ref_count increments (used only for storage analytics and GC, not hard constraints).
- **Lock-free:** Redis `HINCRBY` is atomic — completely eliminates PostgreSQL row-lock contention.
- **Write coalescing:** N concurrent requests are merged into 1 DB batch upsert per flush interval.
- **Safe fallback:** If Redis enqueue fails, falls back to synchronous DB write transparently.

# Implementation Tasks

- [x] New `AssetRefWriter` in `internal/infra/assetrefwriter/writer.go` — Redis-buffered async writer with `Enqueue`, `Start`, `flush`, `flushProject`, `Close`
- [x] Config: `AssetRefWriterCfg` with `Enabled` (default `true`) and `FlushIntervalMs` (default `1000`)
- [x] Replace sync `BatchIncrementAssetRefs` in `StoreMessage` with `Enqueue()` + sync fallback on error
- [x] DI registration in `container.go`, injection into `SessionService`
- [x] Graceful shutdown hook in `main.go` — `writer.Close(ctx)` drains buffer before exit
- [x] Unit tests: 9 test cases covering enqueue, coalescing, multi-call accumulation, timed flush, DB failure recovery, graceful shutdown drain, multiple projects, and metadata SETNX idempotency

# Impact Areas

- [x] API Server

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.