### PR TITLE
perf(api): cache ProjectAuth in Redis and increase DB connection pool

### DIFF
--- a/src/server/api/go/cmd/server/main.go
+++ b/src/server/api/go/cmd/server/main.go
@@ -98,6 +98,7 @@ func main() {
 	engine := router.NewRouter(router.RouterDeps{
 		Config:               cfg,
 		DB:                   db,
+		Redis:                rdb,
 		Log:                  log,
 		SessionHandler:       sessionHandler,
 		DiskHandler:          diskHandler,

--- a/src/server/api/go/configs/config.yaml
+++ b/src/server/api/go/configs/config.yaml
@@ -14,8 +14,8 @@ log:
 
 database:
   dsn: "host=${DATABASE_HOST} user=${DATABASE_USER} password=${DATABASE_PASSWORD} dbname=${DATABASE_NAME} port=${DATABASE_EXPORT_PORT} sslmode=disable TimeZone=UTC"
-  maxOpen: 50
-  maxIdle: 25
+  maxOpen: 100
+  maxIdle: 50
   maxIdleTimeSec: 300
   autoMigrate: true
   enableTLS: ${DATABASE_ENABLE_TLS}

--- a/src/server/api/go/internal/middleware/auth.go
+++ b/src/server/api/go/internal/middleware/auth.go
@@ -1,11 +1,15 @@
 package middleware
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -18,8 +22,14 @@ import (
 	"github.com/memodb-io/Acontext/internal/pkg/utils/tokens"
 )
 
+const (
+	projectAuthCachePrefix = "project:auth:"
+	projectAuthCacheTTL    = 5 * time.Minute
+)
+
 // ProjectAuth returns a middleware that authenticates requests using project bearer tokens.
-func ProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
+// It caches project lookups in Redis to avoid hitting the database on every request.
+func ProjectAuth(cfg *config.Config, db *gorm.DB, rdb *redis.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Create auth span without propagating context to avoid nested span hierarchy
 		authCtx, authSpan := otel.Tracer("middleware").Start(
@@ -47,8 +57,8 @@ func ProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
 
 		lookup := tokens.HMAC256Hex(cfg.Root.SecretPepper, secret)
 
-		var project model.Project
-		if err := db.WithContext(authCtx).Where(&model.Project{SecretKeyHMAC: lookup}).First(&project).Error; err != nil {
+		project, err := lookupProject(authCtx, db, rdb, lookup)
+		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				authSpan.SetAttributes(attribute.Bool("authenticated", false))
 				authSpan.End()
@@ -88,8 +98,40 @@ func ProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
 		)
 		authSpan.End()
 
-		c.Set("project", &project)
+		c.Set("project", project)
 		SetWideEventField(c, "project_id", project.ID.String())
 		c.Next()
 	}
+}
+
+// lookupProject tries Redis cache first, falls back to DB on miss or Redis error.
+func lookupProject(ctx context.Context, db *gorm.DB, rdb *redis.Client, hmac string) (*model.Project, error) {
+	cacheKey := projectAuthCachePrefix + hmac
+
+	// Try Redis first
+	if rdb != nil {
+		data, err := rdb.Get(ctx, cacheKey).Bytes()
+		if err == nil {
+			var project model.Project
+			if json.Unmarshal(data, &project) == nil {
+				return &project, nil
+			}
+		}
+		// On redis.Nil or any other error, fall through to DB
+	}
+
+	// DB lookup
+	var project model.Project
+	if err := db.WithContext(ctx).Where(&model.Project{SecretKeyHMAC: hmac}).First(&project).Error; err != nil {
+		return nil, err
+	}
+
+	// Write-back to Redis (best-effort, don't block on failure)
+	if rdb != nil {
+		if data, err := json.Marshal(&project); err == nil {
+			_ = rdb.Set(ctx, cacheKey, data, projectAuthCacheTTL).Err()
+		}
+	}
+
+	return &project, nil
 }

--- a/src/server/api/go/internal/router/router.go
+++ b/src/server/api/go/internal/router/router.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
@@ -19,6 +20,7 @@ import (
 type RouterDeps struct {
 	Config               *config.Config
 	DB                   *gorm.DB
+	Redis                *redis.Client
 	Log                  *zap.Logger
 	SessionHandler       *handler.SessionHandler
 	DiskHandler          *handler.DiskHandler
@@ -62,7 +64,7 @@ func NewRouter(d RouterDeps) *gin.Engine {
 	{
 		projectAuth := d.ProjectAuthOverride
 		if projectAuth == nil {
-			projectAuth = middleware.ProjectAuth(d.Config, d.DB)
+			projectAuth = middleware.ProjectAuth(d.Config, d.DB, d.Redis)
 		}
 		v1.Use(projectAuth)
 


### PR DESCRIPTION
# Why we need this PR?

Benchmark run with 50 concurrent sessions caused cascading API failures: 88 read timeouts + 8 gateway 504s. Root cause: the `ProjectAuth` middleware hits the database on **every request** with no caching, which saturated the DB connection pool (`maxOpen: 50`) under high concurrency. Even though the `projects` table only has 308 rows with a unique index, queries took up to 1.6s because they were waiting for a free DB connection, not for the query itself.

# Describe your solution

1. **Redis cache for auth lookups** — `ProjectAuth` now checks Redis first (`project:auth:{hmac}`, TTL 5min) before falling back to DB. On Redis errors, it gracefully degrades to the DB path. This eliminates the per-request DB hit for authenticated requests.

2. **Increased DB connection pool** — `maxOpen: 50→100`, `maxIdle: 25→50` to provide more headroom under concurrent load.

# Implementation Tasks

- [x] Add `lookupProject()` helper with Redis-first, DB-fallback pattern
- [x] Update `ProjectAuth` signature to accept `*redis.Client`
- [x] Update `RouterDeps` to include `Redis *redis.Client`
- [x] Pass Redis client from `main.go` into router
- [x] Increase `maxOpen` and `maxIdle` in `config.yaml`
- [x] Verify build and tests pass

# Impact Areas

- [x] API Server

# Checklist

- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.