### PR TITLE
feat(landingpage): trigger skill memory demo animation on scroll into view

### DIFF
--- a/landingpage/src/components/animation/demos/skill-memory-demo.tsx
+++ b/landingpage/src/components/animation/demos/skill-memory-demo.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback, forwardRef } from 'react'
+import { useInView } from 'motion/react'
 import gsap from 'gsap'
 import {
   MessageSquare,
@@ -498,11 +499,14 @@ export function SkillMemoryDemo() {
     ctxRef.current = ctx
   }, [fireSweep])
 
-  // Run on mount
+  // Run when scrolled into view
+  const isInView = useInView(containerRef, { once: true, margin: '-60px' })
+
   useEffect(() => {
+    if (!isInView) return
     runAnimation()
     return () => { if (ctxRef.current) ctxRef.current.revert() }
-  }, [runAnimation])
+  }, [isInView, runAnimation])
 
   return (
     <div


### PR DESCRIPTION
# Why we need this PR?

The skill memory demo animation (`skill-memory-demo.tsx`) plays immediately on page mount, even when the component is below the viewport. This wastes the animation for users who haven't scrolled down yet. `flow-diagram.tsx` already uses `useInView` to defer playback — this PR brings the same behavior to the skill memory demo.

# Describe your solution

Added `useInView` from `motion/react` with `{ once: true, margin: '-60px' }` (same config as `flow-diagram.tsx`) to gate `runAnimation()` so it only fires when the component scrolls into view.

# Implementation Tasks
- [x] Import `useInView` from `motion/react`
- [x] Replace mount-triggered `useEffect` with `isInView`-gated `useEffect`

# Impact Areas
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [x] Other: Landing Page

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.