### PR TITLE
fix(billing): harden concurrency safety and payment failure handling

### DIFF
--- a/dashboard/lib/supabase/supabase.sql
+++ b/dashboard/lib/supabase/supabase.sql
@@ -7,6 +7,7 @@ CREATE TABLE public.organization_billing (
   stripe_subscription_id text UNIQUE,
   plan text NOT NULL DEFAULT 'free'::text,
   pending_plan text,  -- Scheduled plan change (e.g., downgrade at period end)
+  payment_status text NOT NULL DEFAULT 'ok'::text,  -- 'ok' | 'past_due' | 'blocked'
   period_end timestamp with time zone,
   created_at timestamp with time zone DEFAULT now(),
   updated_at timestamp with time zone DEFAULT now(),
@@ -114,6 +115,66 @@ CREATE TABLE public.usage_sync_logs (
   CONSTRAINT usage_sync_logs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
   CONSTRAINT usage_sync_logs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.organization_projects(project_id)
 );
+
+-- Atomic increment for project_usage fields (avoids read-modify-write race conditions)
+-- Called from sync-usage Edge Function to safely increment usage counters.
+create or replace function public.increment_project_usage(
+  p_project_id uuid,
+  p_field text,
+  p_increment integer
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Allowlist: only known usage columns may be incremented.
+  if p_field not in ('current_task', 'current_skill', 'current_fast_skill_search', 'current_agentic_skill_search', 'current_storage') then
+    raise exception 'Invalid field name: %', p_field;
+  end if;
+
+  -- Single atomic upsert: INSERT or UPDATE in one statement.
+  -- Avoids race condition where two concurrent UPDATEs both find NOT FOUND
+  -- and then both attempt INSERT, causing a unique constraint violation.
+  execute format(
+    'INSERT INTO public.project_usage (project_id, %I) VALUES ($1, $2)
+     ON CONFLICT (project_id) DO UPDATE SET %I = COALESCE(public.project_usage.%I, 0) + EXCLUDED.%I,
+     updated_at = now()',
+    p_field, p_field, p_field, p_field
+  ) using p_project_id, p_increment;
+end;
+$$;
+
+-- Atomically claim a monthly reset checkpoint for an org.
+-- Returns true if this call claimed it (i.e., the timestamp was actually changed),
+-- false if it was already set to the current month's timestamp.
+-- Uses ON CONFLICT with a WHERE clause so the UPDATE only fires when the value differs.
+create or replace function public.try_claim_monthly_reset(
+  p_checkpoint_id text,
+  p_month_start_timestamp bigint
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row_count integer;
+begin
+  INSERT INTO public.usage_sync_global_checkpoint (id, last_processed_to_timestamp)
+  VALUES (p_checkpoint_id, p_month_start_timestamp)
+  ON CONFLICT (id) DO UPDATE
+    SET last_processed_to_timestamp = EXCLUDED.last_processed_to_timestamp
+    WHERE public.usage_sync_global_checkpoint.last_processed_to_timestamp != EXCLUDED.last_processed_to_timestamp;
+
+  -- ROW_COUNT is 0 when the WHERE clause suppresses the update (already claimed),
+  -- 1 when a row was actually inserted or updated.
+  -- FOUND cannot be used here because it is true even when the conditional UPDATE is skipped.
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  return v_row_count > 0;
+end;
+$$;
 
 -- Database function to create organization
 -- Uses auth.uid() to get the current authenticated user

--- a/dashboard/supabase/functions/stripe-webhook/index.ts
+++ b/dashboard/supabase/functions/stripe-webhook/index.ts
@@ -167,6 +167,7 @@ Deno.serve(async (req: Request) => {
               stripe_subscription_id: null,
               period_end: null,
               pending_plan: null,
+              payment_status: "ok",
             })
             .eq("organization_id", organizationId);
 
@@ -198,31 +199,40 @@ Deno.serve(async (req: Request) => {
         // Check if subscription is scheduled for cancellation
         if (subscription.cancel_at_period_end) {
           const downgradeTarget = subscription.metadata.downgrade_to;
+          const validDowngradePlans = ["free", "pro", "team"];
+          const validatedDowngrade = (downgradeTarget && validDowngradePlans.includes(downgradeTarget)) ? downgradeTarget : undefined;
           console.log(
             `Subscription ${subscription.id} is scheduled for cancellation${
-              downgradeTarget ? ` (downgrade to ${downgradeTarget})` : ""
+              validatedDowngrade ? ` (downgrade to ${validatedDowngrade})` : ""
             }`
           );
 
-          // Update with pending_plan if downgrading
-          if (downgradeTarget) {
-            const { error } = await supabase
-              .from("organization_billing")
-              .update({
-                pending_plan: downgradeTarget,
-              })
-              .eq("organization_id", organizationId);
+          // Always update period_end and stripe_subscription_id even when scheduled for cancellation
+          const periodEnd = await getPeriodEnd(subscription);
+          const updateData: Record<string, unknown> = {
+            stripe_subscription_id: subscription.id,
+            period_end: periodEnd,
+          };
+          if (validatedDowngrade) {
+            updateData.pending_plan = validatedDowngrade;
+          }
 
-            if (error) {
-              console.error(
-                `Error setting pending_plan for organization ${organizationId}:`,
-                error
-              );
-            } else {
-              console.log(
-                `Set pending_plan to ${downgradeTarget} for organization ${organizationId}`
-              );
-            }
+          const { error } = await supabase
+            .from("organization_billing")
+            .update(updateData)
+            .eq("organization_id", organizationId);
+
+          if (error) {
+            console.error(
+              `Error updating organization ${organizationId} for scheduled cancellation:`,
+              error
+            );
+          } else {
+            console.log(
+              `Updated organization ${organizationId}: period_end=${periodEnd}${
+                validatedDowngrade ? `, pending_plan=${validatedDowngrade}` : ""
+              }`
+            );
           }
           break;
         }
@@ -245,6 +255,7 @@ Deno.serve(async (req: Request) => {
             stripe_subscription_id: subscription.id,
             period_end: periodEnd,
             pending_plan: null, // Clear any pending plan
+            payment_status: "ok", // Clear any payment failure state
           })
           .eq("organization_id", organizationId)
           .select();
@@ -273,17 +284,20 @@ Deno.serve(async (req: Request) => {
           break;
         }
 
-        // Check if this was a scheduled downgrade to free
+        // Check if this was a scheduled downgrade — validate against known plans
+        const validPlans = ["free", "pro", "team"];
         const downgradeTarget = subscription.metadata.downgrade_to;
+        const validatedPlan = (downgradeTarget && validPlans.includes(downgradeTarget)) ? downgradeTarget : "free";
 
         // Reset to free plan when subscription is cancelled
         const { error } = await supabase
           .from("organization_billing")
           .update({
-            plan: downgradeTarget || "free",
+            plan: validatedPlan,
             stripe_subscription_id: null,
             period_end: null,
             pending_plan: null,
+            payment_status: "ok",
           })
           .eq("organization_id", organizationId);
 
@@ -296,9 +310,7 @@ Deno.serve(async (req: Request) => {
         }
 
         console.log(
-          `Cancelled subscription for organization ${organizationId}, reset to ${
-            downgradeTarget || "free"
-          } plan`
+          `Cancelled subscription for organization ${organizationId}, reset to ${validatedPlan} plan`
         );
         break;
       }
@@ -476,10 +488,39 @@ Deno.serve(async (req: Request) => {
           `Updating period_end for organization ${organizationId} to: ${periodEnd}`
         );
 
+        // Determine invoice type so we only clear the matching payment_status.
+        // Plan invoice success clears 'past_due'; metered invoice success clears 'blocked'.
+        // This prevents a plan invoice success from incorrectly clearing a 'blocked' state
+        // caused by an unpaid metered invoice (and vice-versa).
+        const hasMeteredLineItems = invoice.lines?.data?.some(
+          (line) => {
+            const price = line.price as Stripe.Price;
+            return price?.type === "metered" || price?.recurring?.meter != null;
+          }
+        );
+        const isMeteredInvoice =
+          invoice.billing_reason === "subscription_threshold" || hasMeteredLineItems;
+
+        // Fetch current payment_status to decide whether to clear it
+        const { data: currentBilling } = await supabase
+          .from("organization_billing")
+          .select("payment_status")
+          .eq("organization_id", organizationId)
+          .maybeSingle();
+
+        const currentStatus = currentBilling?.payment_status || "ok";
+        let newPaymentStatus = currentStatus;
+        if (isMeteredInvoice && currentStatus === "blocked") {
+          newPaymentStatus = "ok";
+        } else if (!isMeteredInvoice && currentStatus === "past_due") {
+          newPaymentStatus = "ok";
+        }
+
         const { data, error } = await supabase
           .from("organization_billing")
           .update({
             period_end: periodEnd,
+            payment_status: newPaymentStatus,
           })
           .eq("organization_id", organizationId)
           .select();
@@ -493,7 +534,7 @@ Deno.serve(async (req: Request) => {
         }
 
         console.log(
-          `Payment succeeded for organization ${organizationId}, period_end updated to: ${periodEnd}`,
+          `Payment succeeded for organization ${organizationId}, period_end updated to: ${periodEnd}, payment_status: ${currentStatus} → ${newPaymentStatus} (${isMeteredInvoice ? "metered" : "plan"} invoice)`,
           data
         );
         break;
@@ -516,31 +557,75 @@ Deno.serve(async (req: Request) => {
           break;
         }
 
-        console.error(`Payment failed for organization ${organizationId}`);
+        console.error(`Payment failed for organization ${organizationId}, billing_reason: ${invoice.billing_reason}`);
 
-        // Check if this subscription was activated with a 100% off promo code
-        // and has no payment method (promo code expired scenario)
-        const wasActivatedWithPromo = subscription.metadata.activated_with_promo === "true";
-        const hasNoPaymentMethod = !subscription.default_payment_method;
+        // Determine if this is a metered usage invoice or a plan subscription invoice.
+        // Legacy metered prices have price.type === 'metered'.
+        // New Stripe Billing Meters have price.type === 'recurring' with price.recurring.meter set.
+        // billing_reason === 'subscription_threshold' also indicates metered usage.
+        const hasMeteredLineItems = invoice.lines?.data?.some(
+          (line) => {
+            const price = line.price as Stripe.Price;
+            return price?.type === "metered" || price?.recurring?.meter != null;
+          }
+        );
+        const isMeteredInvoice =
+          invoice.billing_reason === "subscription_threshold" || hasMeteredLineItems;
 
-        if (wasActivatedWithPromo && hasNoPaymentMethod) {
+        if (isMeteredInvoice) {
+          // Metered usage payment failed → hard block all writes
           console.log(
-            `Subscription ${subscriptionId} was activated with promo code and has no payment method. ` +
-            `Promo code likely expired. Scheduling downgrade to free plan.`
+            `Metered usage payment failed for organization ${organizationId}, setting payment_status to blocked`
           );
 
+          const { error } = await supabase
+            .from("organization_billing")
+            .update({
+              payment_status: "blocked",
+            })
+            .eq("organization_id", organizationId);
+
+          if (error) {
+            console.error(
+              `Error setting payment_status=blocked for organization ${organizationId}:`,
+              error
+            );
+          } else {
+            console.log(
+              `Set payment_status=blocked for organization ${organizationId} due to metered payment failure`
+            );
+          }
+        } else {
+          // Plan subscription payment failed → set past_due and schedule downgrade to free
+          console.log(
+            `Plan payment failed for organization ${organizationId}, setting payment_status to past_due and scheduling downgrade`
+          );
+
+          const { error: statusError } = await supabase
+            .from("organization_billing")
+            .update({
+              payment_status: "past_due",
+            })
+            .eq("organization_id", organizationId);
+
+          if (statusError) {
+            console.error(
+              `Error setting payment_status=past_due for organization ${organizationId}:`,
+              statusError
+            );
+          }
+
+          // Schedule downgrade to free plan
           try {
-            // Cancel subscription at period end (auto-downgrade to free)
             await stripe.subscriptions.update(subscriptionId, {
               cancel_at_period_end: true,
               metadata: {
                 ...subscription.metadata,
                 downgrade_to: "free",
-                downgrade_reason: "promo_expired_no_payment_method",
+                downgrade_reason: "plan_payment_failed",
               },
             });
 
-            // Update database to set pending_plan
             const { error } = await supabase
               .from("organization_billing")
               .update({
@@ -555,12 +640,12 @@ Deno.serve(async (req: Request) => {
               );
             } else {
               console.log(
-                `Set pending_plan to free for organization ${organizationId} due to promo expiration`
+                `Scheduled downgrade to free for organization ${organizationId} due to plan payment failure`
               );
             }
           } catch (err) {
             console.error(
-              `Error handling promo expiration for organization ${organizationId}:`,
+              `Error scheduling downgrade for organization ${organizationId}:`,
               err
             );
           }

--- a/dashboard/supabase/functions/sync-usage/index.ts
+++ b/dashboard/supabase/functions/sync-usage/index.ts
@@ -137,40 +137,31 @@ function getCurrentHourTimestamp(): number {
   return Math.floor(now.getTime() / 1000)
 }
 
-// 检查指定 org 本月是否已经重置过
-async function hasOrgResetThisMonth(orgId: string): Promise<boolean> {
+// Atomically try to claim the monthly reset checkpoint for an org.
+// Returns true if this invocation claimed the reset (i.e., should proceed with reset).
+// Uses a Postgres RPC function with INSERT ... ON CONFLICT + WHERE clause to guarantee
+// only one concurrent caller succeeds (the upsert only fires when the value differs).
+async function tryClaimMonthlyReset(orgId: string): Promise<boolean> {
   const monthStartTimestamp = getCurrentMonthStartTimestamp()
   const checkpointId = `monthly_reset_${orgId}`
 
-  const { data: checkpoint } = await supabase
-    .from("usage_sync_global_checkpoint")
-    .select("last_processed_to_timestamp")
-    .eq("id", checkpointId)
-    .maybeSingle()
+  const { data: claimed, error } = await supabase.rpc("try_claim_monthly_reset", {
+    p_checkpoint_id: checkpointId,
+    p_month_start_timestamp: monthStartTimestamp,
+  })
 
-  if (!checkpoint) {
-    return false // 没有记录，说明还没重置过
+  if (error) {
+    console.error(`Failed to claim monthly reset checkpoint for ${orgId}:`, error)
+    return false
   }
 
-  // 检查 checkpoint 的时间戳是否等于当前月份第一天的时间戳
-  return checkpoint.last_processed_to_timestamp === monthStartTimestamp
-}
-
-// 记录指定 org 本月已重置
-async function markOrgMonthAsReset(orgId: string): Promise<void> {
-  const monthStartTimestamp = getCurrentMonthStartTimestamp()
-  const checkpointId = `monthly_reset_${orgId}`
-
-  await supabase.from("usage_sync_global_checkpoint").upsert({
-    id: checkpointId,
-    last_processed_to_timestamp: monthStartTimestamp,
-  })
+  return claimed === true
 }
 
 // 重置指定 org 的月初计数（针对需要重置的 metrics）
 async function resetOrgMonthlyCounters(orgId: string): Promise<void> {
-  // 检查是否已经重置过本月
-  if (await hasOrgResetThisMonth(orgId)) {
+  // Atomically claim the reset checkpoint — only one invocation proceeds
+  if (!(await tryClaimMonthlyReset(orgId))) {
     console.log(`Organization ${orgId} monthly counters already reset this month, skipping`)
     return
   }
@@ -221,9 +212,6 @@ async function resetOrgMonthlyCounters(orgId: string): Promise<void> {
       .eq("organization_id", orgId)
       .neq(usageField, 0) // 只更新非零值，提高效率
   }
-
-  // 记录本月已重置
-  await markOrgMonthAsReset(orgId)
 
   console.log(`Monthly counters reset completed for organization ${orgId}`)
 }
@@ -312,17 +300,25 @@ serve(async (req) => {
     }
 
     // Step 5: 先执行月初重置
+    // Track orgs whose reset failed — skip them in all subsequent steps
+    // to prevent Stripe from being billed on stale (pre-reset) cumulative counters.
+    const resetFailedOrgs = new Set<string>()
     for (const orgId of orgIdSet) {
       try {
         await resetOrgMonthlyCounters(orgId)
       } catch (error) {
         console.error(`Failed to reset monthly counters for ${orgId}:`, error)
+        resetFailedOrgs.add(orgId)
       }
+    }
+    if (resetFailedOrgs.size > 0) {
+      console.warn(`Skipping processing for ${resetFailedOrgs.size} org(s) with failed monthly reset: ${[...resetFailedOrgs].join(", ")}`)
     }
 
     // Step 5.5: 记录每个 org 处理前的 usage（用于 Stripe 超量计算）
     const orgInitialUsage = new Map<string, OrgUsageSnapshot>()
     for (const orgId of orgIdSet) {
+      if (resetFailedOrgs.has(orgId)) continue
       const { data: usage } = await supabase
         .from("organization_usage")
         .select("current_task, current_skill, current_fast_skill_search, current_agentic_skill_search, current_storage")
@@ -348,6 +344,7 @@ serve(async (req) => {
           console.warn(`No orgId found for project: ${m.project_id}`)
           continue
         }
+        if (resetFailedOrgs.has(orgId)) continue
         const processed = await processMetricWithoutStripe(m, orgId)
         if (processed) {
           processedMetrics.push(m)
@@ -359,6 +356,7 @@ serve(async (req) => {
 
     // Step 7: 聚合到 organization_usage
     for (const orgId of orgIdSet) {
+      if (resetFailedOrgs.has(orgId)) continue
       try {
         await aggregateOrganizationUsage(orgId)
       } catch (error) {
@@ -369,6 +367,7 @@ serve(async (req) => {
     // Step 8: 上报 Stripe
     // 8.1 上报 incremental metrics（只对有变化的 org，基于处理前后的 usage 差值）
     for (const orgId of orgIdSet) {
+      if (resetFailedOrgs.has(orgId)) continue
       try {
         const initialUsage = orgInitialUsage.get(orgId)
         if (!initialUsage) continue
@@ -390,16 +389,16 @@ serve(async (req) => {
     // 批量查询需要的数据，避免每个 metric 都查询数据库
     const quotaItems: QuotaItem[] = []
 
-    // 6.1 批量查询所有 org 的 billing 信息
-    const orgBillingMap = new Map<string, { plan: string }>()
+    // 6.1 批量查询所有 org 的 billing 信息（包含 payment_status）
+    const orgBillingMap = new Map<string, { plan: string; payment_status: string }>()
     const { data: allBillings } = await supabase
       .from("organization_billing")
-      .select("organization_id, plan")
+      .select("organization_id, plan, payment_status")
       .in("organization_id", [...orgIdSet])
 
     if (allBillings) {
       for (const b of allBillings) {
-        orgBillingMap.set(b.organization_id, { plan: b.plan })
+        orgBillingMap.set(b.organization_id, { plan: b.plan, payment_status: b.payment_status || "ok" })
       }
     }
 
@@ -447,6 +446,47 @@ serve(async (req) => {
       } catch (error) {
         console.error(`Failed to check quota for metric:`, m, error)
       }
+    }
+
+    // 6.5 For payment-blocked orgs, force excess=true for ALL metric tags on ALL their projects.
+    // This blocks both storage.usage (Go API) and task.created (CORE) enforcement.
+    const blockedOrgIds = [...orgBillingMap.entries()]
+      .filter(([, billing]) => billing.payment_status === "blocked")
+      .map(([orgId]) => orgId)
+
+    if (blockedOrgIds.length > 0) {
+      // Fetch ALL project_ids for blocked orgs from DB (not just those in current batch)
+      // to ensure enforcement even for projects that didn't send metrics this invocation.
+      const { data: blockedProjectRows } = await supabase
+        .from("organization_projects")
+        .select("project_id")
+        .in("organization_id", blockedOrgIds)
+      const blockedProjectIds = (blockedProjectRows ?? []).map((p) => p.project_id)
+
+      // All tracked metric tags that need blocking
+      const allTrackedTags = Object.keys(METRIC_HANDLERS)
+
+      for (const projectId of blockedProjectIds) {
+        for (const tag of allTrackedTags) {
+          // Force excess=true, overriding any existing excess=false entry
+          const existingIdx = quotaItems.findIndex(
+            (q) => q.project_id === projectId && q.tag === tag
+          )
+          if (existingIdx === -1) {
+            quotaItems.push({
+              project_id: projectId,
+              tag,
+              excess: true,
+            })
+          } else {
+            quotaItems[existingIdx].excess = true
+          }
+        }
+      }
+
+      console.log(
+        `Payment-blocked orgs: ${blockedOrgIds.join(", ")} — forced excess=true for ${blockedProjectIds.length} projects`
+      )
     }
 
     // 6️⃣ 返回结果（包含 quota 检查）
@@ -819,56 +859,33 @@ async function incrementUsage(
 ) {
   if (!config.usageField) return
 
-  // 先查询当前值（project 级别）
-  const { data: currentUsage } = await supabase
-    .from("project_usage")
-    .select(config.usageField)
-    .eq("project_id", projectId)
-    .maybeSingle()
+  // Use Postgres RPC for atomic increment to avoid read-modify-write race conditions.
+  // The function atomically: INSERT if not exists, or UPDATE field = field + increment.
+  const { error } = await supabase.rpc("increment_project_usage", {
+    p_project_id: projectId,
+    p_field: config.usageField,
+    p_increment: increment,
+  })
 
-  if (!currentUsage) {
-    // 如果记录不存在，创建新记录
-    await supabase.from("project_usage").insert({
-      project_id: projectId,
-      [config.usageField]: increment,
-    })
-  } else {
-    // 更新使用量（累加）
-    const currentValue = (currentUsage[config.usageField] as number) || 0
-    await supabase
-      .from("project_usage")
-      .update({
-        [config.usageField]: currentValue + increment,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("project_id", projectId)
+  if (error) {
+    console.error(`Failed to atomically increment usage for project ${projectId}, field ${config.usageField}:`, error)
   }
 }
 
 // 更新 storage usage（只更新数据，不上报 Stripe）
 async function updateStorageUsage(projectId: string, storageValue: number): Promise<void> {
-  // 直接设置 storage（因为 metric.increment 是总量，不是增量）
-  const { data: currentUsage } = await supabase
+  // Atomic upsert to avoid read-then-write race condition on first insert.
+  // Storage is a total (not a delta), so we always SET the value.
+  const { error } = await supabase
     .from("project_usage")
-    .select("current_storage")
-    .eq("project_id", projectId)
-    .maybeSingle()
-
-  if (!currentUsage) {
-    // 如果记录不存在，创建新记录
-    await supabase.from("project_usage").insert({
+    .upsert({
       project_id: projectId,
       current_storage: storageValue,
-    })
-  } else {
-    // 直接设置为 storageValue（因为是总量）
-    await supabase
-      .from("project_usage")
-      .update({
-        current_storage: storageValue,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("project_id", projectId)
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "project_id" })
+
+  if (error) {
+    console.error(`Failed to upsert storage usage for project ${projectId}:`, error)
   }
 }
 

--- a/src/server/api/go/internal/middleware/auth_admin.go
+++ b/src/server/api/go/internal/middleware/auth_admin.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"strings"
@@ -96,11 +97,13 @@ func AdminProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
 		// Parse and verify project token (base64 JSON with signature)
 		tokenData, err := tokens.ParseAndVerifyProjectToken(secret, cfg.Root.ApiBearerToken)
 		if err != nil {
+			authSpan.SetAttributes(attribute.Bool("authenticated", false))
 			authSpan.End()
 			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Invalid token format"))
 			return
 		}
 		if !tokenData.Valid {
+			authSpan.SetAttributes(attribute.Bool("authenticated", false))
 			authSpan.End()
 			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Invalid token signature"))
 			return
@@ -110,10 +113,12 @@ func AdminProjectAuth(cfg *config.Config, db *gorm.DB) gin.HandlerFunc {
 		var project model.Project
 		if err := db.WithContext(c.Request.Context()).Where(&model.Project{ID: tokenData.ProjectID}).First(&project).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
+				authSpan.SetAttributes(attribute.Bool("authenticated", false))
 				authSpan.End()
 				c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Project not found"))
 				return
 			}
+			authSpan.SetAttributes(attribute.Bool("authenticated", false))
 			authSpan.RecordError(err)
 			authSpan.End()
 			c.AbortWithStatusJSON(http.StatusInternalServerError, serializer.DBErr("", err))
@@ -153,7 +158,7 @@ func MetricsAuth(cfg *config.Config) gin.HandlerFunc {
 			return
 		}
 
-		if raw != cfg.Root.ApiBearerToken {
+		if subtle.ConstantTimeCompare([]byte(raw), []byte(cfg.Root.ApiBearerToken)) != 1 {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, serializer.AuthErr("Unauthorized"))
 			return
 		}

--- a/src/server/api/go/internal/modules/handler/metric.go
+++ b/src/server/api/go/internal/modules/handler/metric.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -53,28 +54,37 @@ func (h *MetricsHandler) PushMetrics(c *gin.Context) {
 	now := time.Now().UTC()
 	to := now
 
-	// Check last request time from Redis
+	// Acquire distributed lock to prevent concurrent PushMetrics from double-reporting to Stripe.
+	// TTL must exceed max execution time (30s HTTP timeout + DB overhead).
+	const pushMetricsLockKey = "push_metrics:lock"
+	const pushMetricsLockTTL = 5 * time.Minute
+	ok, err := h.redis.SetNX(ctx, pushMetricsLockKey, "1", pushMetricsLockTTL).Result()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, serializer.DBErr("failed to acquire lock", err))
+		return
+	}
+	if !ok {
+		c.JSON(http.StatusTooManyRequests, serializer.ParamErr("another push is in progress, please try again later", nil))
+		return
+	}
+	// Release lock when done. Must be registered AFTER the !ok check above,
+	// otherwise returning early on !ok would delete the other caller's lock.
+	defer h.redis.Del(context.Background(), pushMetricsLockKey)
+
+	// Check last request time from Redis to determine the "from" window
 	var from time.Time
 	lastRequestStr, err := h.redis.Get(ctx, h.cfg.Metrics.PushLastRequestKey).Result()
 	switch err {
 	case nil:
-		// Parse last request time
 		lastRequest, parseErr := time.Parse(time.RFC3339, lastRequestStr)
 		if parseErr == nil {
-			// Rate limiting: if within 1 minute, return error
-			if now.Sub(lastRequest) < time.Minute {
-				c.JSON(http.StatusTooManyRequests, serializer.ParamErr("request too frequent, please try again later", nil))
-				return
-			}
 			from = lastRequest
 		} else {
 			from = to.Add(-1 * time.Hour)
 		}
 	case redis.Nil:
-		// Key not found, use default
 		from = to.Add(-1 * time.Hour)
 	default:
-		// Redis error
 		c.JSON(http.StatusInternalServerError, serializer.DBErr("failed to read from Redis", err))
 		return
 	}
@@ -101,6 +111,9 @@ func (h *MetricsHandler) PushMetrics(c *gin.Context) {
 	}
 
 	if len(metricsOut.Metrics) == 0 {
+		// Advance the time window even when no metrics exist, so subsequent calls
+		// don't re-scan the same range.
+		_ = h.redis.Set(ctx, h.cfg.Metrics.PushLastRequestKey, now.Format(time.RFC3339), 0).Err()
 		c.JSON(http.StatusOK, serializer.Response{Msg: "no metrics to push"})
 		return
 	}

--- a/src/server/api/go/internal/modules/repo/metric.go
+++ b/src/server/api/go/internal/modules/repo/metric.go
@@ -2,11 +2,13 @@ package repo
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/memodb-io/Acontext/internal/modules/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type MetricRepo interface {
@@ -71,36 +73,51 @@ func (r *metricRepo) CreateMetrics(ctx context.Context, metrics []model.Metric) 
 // SaveMetrics upserts metrics by project_id and tag.
 // If a metric with the same project_id and tag exists, it updates the increment value.
 // If not, it creates a new record.
+//
+// Concurrency: The caller (PushMetrics handler) holds a Redis distributed lock,
+// so concurrent calls to this function are already serialized at the handler level.
+// The transaction with SELECT FOR UPDATE provides defense-in-depth for the update path.
+// For the insert path (ErrRecordNotFound), a duplicate row is possible if the Redis lock
+// is bypassed; the caller must ensure serialization.
 func (r *metricRepo) SaveMetrics(ctx context.Context, metrics []model.Metric) error {
 	if len(metrics) == 0 {
 		return nil
 	}
 
-	for _, metric := range metrics {
-		var existing model.Metric
-		err := r.db.WithContext(ctx).
-			Where("project_id = ? AND tag = ?", metric.ProjectID, metric.Tag).
-			Order("created_at DESC").
-			First(&existing).Error
+	// Sort by (project_id, tag) to ensure consistent lock ordering and prevent deadlocks
+	// when concurrent transactions acquire SELECT FOR UPDATE locks.
+	sort.Slice(metrics, func(i, j int) bool {
+		if metrics[i].ProjectID.String() != metrics[j].ProjectID.String() {
+			return metrics[i].ProjectID.String() < metrics[j].ProjectID.String()
+		}
+		return metrics[i].Tag < metrics[j].Tag
+	})
 
-		if err == gorm.ErrRecordNotFound {
-			// Create new record
-			if err := r.db.WithContext(ctx).Create(&metric).Error; err != nil {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, metric := range metrics {
+			var existing model.Metric
+			err := tx.
+				Clauses(clause.Locking{Strength: "UPDATE"}).
+				Where("project_id = ? AND tag = ?", metric.ProjectID, metric.Tag).
+				Order("created_at DESC").
+				First(&existing).Error
+
+			if err == gorm.ErrRecordNotFound {
+				if err := tx.Create(&metric).Error; err != nil {
+					return err
+				}
+			} else if err != nil {
 				return err
-			}
-		} else if err != nil {
-			return err
-		} else {
-			// Update existing record
-			if err := r.db.WithContext(ctx).
-				Model(&existing).
-				Update("increment", metric.Increment).Error; err != nil {
-				return err
+			} else {
+				if err := tx.
+					Model(&existing).
+					Update("increment", metric.Increment).Error; err != nil {
+					return err
+				}
 			}
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // DeleteByProjectIDAndTag deletes all metrics with the given project_id and tag.


### PR DESCRIPTION

# Why we need this PR?

The billing system had several concurrency vulnerabilities and incomplete payment failure handling:
1. **Race conditions** in usage counter increments (read-modify-write pattern) could cause lost updates under concurrent sync-usage invocations
2. **No distributed lock** on PushMetrics allowed concurrent calls to double-report usage to Stripe
3. **Monthly reset checkpoint** used a non-atomic check-then-set pattern, allowing duplicate resets
4. **Payment failures** were only handled for promo-expired subscriptions, leaving general payment failures (card decline, insufficient funds) untracked
5. **Timing attack** vulnerability in MetricsAuth token comparison

# Describe your solution

### Atomic DB operations (Supabase)
- New `increment_project_usage` Postgres RPC: atomic `INSERT ... ON CONFLICT DO UPDATE` replaces read-then-write pattern for usage counters
- New `try_claim_monthly_reset` Postgres RPC: atomic checkpoint claim ensures only one concurrent caller performs the reset
- `updateStorageUsage` converted to use `.upsert()` with `onConflict`

### Distributed lock (Go API)
- Redis `SetNX` lock on PushMetrics (5min TTL) prevents concurrent Stripe double-reporting
- `SaveMetrics` wrapped in DB transaction with `SELECT FOR UPDATE` + sorted lock ordering to prevent deadlocks

### Payment status tracking
- New `payment_status` column on `organization_billing`: `ok` | `past_due` | `blocked`
- Metered invoice failure → `blocked` (hard-blocks all writes via `excess=true` on all metric tags)
- Plan invoice failure → `past_due` + schedule downgrade to free
- Payment success selectively clears only the matching failure type (metered clears `blocked`, plan clears `past_due`)

### Safety improvements
- `downgrade_to` metadata validated against allowlist `["free", "pro", "team"]`
- Failed monthly resets tracked in `resetFailedOrgs` — all subsequent steps skip those orgs
- `subtle.ConstantTimeCompare` for MetricsAuth token check
- Auth failure spans now consistently set `authenticated=false`

# Implementation Tasks
- [x] Add `payment_status` column to `organization_billing` schema
- [x] Create `increment_project_usage` Postgres RPC function
- [x] Create `try_claim_monthly_reset` Postgres RPC function
- [x] Replace read-modify-write in `incrementUsage` with RPC call
- [x] Replace read-modify-write in `updateStorageUsage` with upsert
- [x] Replace `hasOrgResetThisMonth`/`markOrgMonthAsReset` with atomic `tryClaimMonthlyReset`
- [x] Add Redis distributed lock to PushMetrics handler
- [x] Wrap SaveMetrics in transaction with SELECT FOR UPDATE
- [x] Implement metered vs plan invoice failure differentiation
- [x] Add payment-blocked org enforcement (force excess=true)
- [x] Add resetFailedOrgs tracking and skip logic
- [x] Validate downgrade_to metadata against plan allowlist
- [x] Fix constant-time token comparison in MetricsAuth
- [x] Add authenticated=false span attributes on auth failure paths

# Impact Areas
- [x] API Server
- [x] Dashboard
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] CLI Tool
- [ ] Documentation
- [ ] Other: ...

# Checklist
- [x] Open your pull request against the `dev` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.