### PR TITLE
fix(docs): make shiki patch resilient to bundler param name changes

### DIFF
--- a/docs/scripts/patch-worker.mjs
+++ b/docs/scripts/patch-worker.mjs
@@ -42,10 +42,21 @@ const __EXTERNAL_MODULES = {
 handler = staticImports + handler;
 
 // Patch externalImport to check __EXTERNAL_MODULES first
+// The parameter name varies across bundler versions (id, id2, etc.), so match any identifier
+let externalImportPatched = false;
 handler = handler.replace(
-  /async function externalImport\(id\)\{let raw;try\{/g,
-  'async function externalImport(id){let raw;try{if(typeof __EXTERNAL_MODULES!=="undefined"&&id in __EXTERNAL_MODULES){raw=__EXTERNAL_MODULES[id]}else '
+  /async function externalImport\((\w+)\)\{let raw;try\{/g,
+  (_match, paramName) => {
+    externalImportPatched = true;
+    return `async function externalImport(${paramName}){let raw;try{if(typeof __EXTERNAL_MODULES!=="undefined"&&${paramName} in __EXTERNAL_MODULES){raw=__EXTERNAL_MODULES[${paramName}]}else `;
+  }
 );
+
+if (!externalImportPatched) {
+  console.error('ERROR: Failed to patch externalImport function — regex did not match.');
+  console.error('The bundled handler.mjs may have changed its function signature.');
+  process.exit(1);
+}
 
 writeFileSync(HANDLER_PATH, handler);
 


### PR DESCRIPTION
# Why we need this PR?
> After merging #490 (dependency updates), the docs site at docs.acontext.io started returning 500 Internal Server Error on Cloudflare Workers.

# Describe your solution
The dependency update caused Turbopack to rename the `externalImport` function parameter from `id` to `id2` in the bundled `handler.mjs`. The `patch-worker.mjs` script had a hardcoded regex matching `externalImport(id)`, so the shiki module pre-resolution patch **silently failed**, leaving shiki modules unresolvable at runtime.

Fix:
- Use `(\w+)` capture group instead of literal `id` to match any parameter name
- Dynamically reference the captured param name in the replacement string
- Add a validation check that exits with error code 1 if the patch fails to match (prevents silent failures in the future)

# Implementation Tasks
- [x] Fix regex in `docs/scripts/patch-worker.mjs` to handle variable parameter names
- [x] Add build-time validation to catch future patch failures
- [x] Verified locally: `pnpm build:cf` + `wrangler dev --local` → HTTP 200 OK

# Impact Areas
- [x] Documentation
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [ ] Dashboard
- [ ] CLI Tool
- [ ] Other: ...

# Checklist
- [x] Open your pull request against the `dev` branch.
- [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [x] Tests are added or modified as needed to cover code changes.