### PR TITLE
fix(api): improve error message for file not found in GetAgentSkillFile

### DIFF
--- a/src/server/api/go/internal/modules/handler/agent_skills.go
+++ b/src/server/api/go/internal/modules/handler/agent_skills.go
@@ -272,7 +272,7 @@ func (h *AgentSkillsHandler) GetAgentSkillFile(c *gin.Context) {
 	output, err := h.svc.GetFile(c.Request.Context(), project.ID, id, filePath, expire)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, serializer.DBErr("", err))
+			c.JSON(http.StatusNotFound, serializer.Err(http.StatusNotFound, "file not found", err))
 		} else {
 			c.JSON(http.StatusInternalServerError, serializer.DBErr("", err))
 		}


### PR DESCRIPTION
  # Why we need this PR?
  > This should close Issue (N/A)

  When calling `get_skill_file` for a non-existent file, the API returns a confusing "database error" message. Users can't
  tell if it's a server-side database issue or simply a missing file.

  # Describe your solution
  Changed the error response in `GetAgentSkillFile` handler to return a clear "file not found" message instead of the
  generic "database error".

  Previously:
  APIError: 404: database error

  Now:
  APIError: 404: file not found

  # Implementation Tasks
  - [x] Modified `GetAgentSkillFile` handler to use clear error message
  - [x] Tested manually

  # Impact Areas
  Which part of Acontext would this feature affect?
  - [ ] Client SDK (Python)
  - [ ] Client SDK (TypeScript)
  - [ ] Core Service
  - [x] API Server
  - [ ] Dashboard
  - [ ] CLI Tool
  - [ ] Documentation
  - [ ] Other: ...

  # Checklist
  - [x] Open your pull request against the `dev` branch.
  - [x] All tests pass in available continuous integration systems (e.g., GitHub Actions).
  - [x] Tests are added or modified as needed to cover code changes.
