### PR TITLE
feat(core): add skill_writing status for session learning flow

### DIFF
--- a/src/server/core/acontext_core/service/skill_learner.py
+++ b/src/server/core/acontext_core/service/skill_learner.py
@@ -63,6 +63,11 @@ async def process_skill_distillation(body: SkillLearnTask, message: Message):
             await LS.update_session_status(db_session, body.session_id, "completed")
         return
 
+    # Set status to skill_writing before publishing to skill agent
+    # This indicates that distillation is done and skill files are being written
+    async with DB_CLIENT.get_session_context() as db_session:
+        await LS.update_session_status(db_session, body.session_id, "skill_writing")
+
     await publish_mq(
         exchange_name=EX.learning_skill,
         routing_key=RK.learning_skill_agent,


### PR DESCRIPTION
# Why we need this PR?
  > This should close Issue (N/A)

  Previously, session status went directly from "distilling" to "completed" after distillation, even though skill files were
   still being written by the skill agent. This caused confusion for clients waiting for learning to complete.

  **Problem observed in logs:**
  [14:08:02] session 状态 = completed  ← distillation done
  [14:08:03] skills: files=1               ← but skill file not yet created
  [14:08:15] skills: files=1               ← still not created
  [14:08:26] skills: files=2               ← finally created (24s later!)

  Clients thought learning was complete when `wait_for_learning` returned, but skill files were still being written.

  # Describe your solution
  Added a new `skill_writing` status to the session lifecycle.

  **New status flow:**
  pending → distilling → skill_writing → completed

  **Changes made:**
  - In `skill_learner.py`, set session status to `skill_writing` after distillation completes and before publishing to skill
   agent
  - The `skill_writing` status is automatically handled by existing `wait_for_learning` logic (it's not in the `terminal`
  set, so clients will continue polling until `completed`)

  **After this PR:**
  [14:08:02] session 状态 = skill_writing  ← distillation done, writing files
  [14:08:26] session 状态 = completed      ← skill files fully written
  [14:08:26] wait_for_learning returns     ← client can now safely fetch files

  # Implementation Tasks
  - [x] Added `skill_writing` status update in `process_skill_distillation`
  - [x] Verified existing `wait_for_learning` handles the new status correctly

  # Impact Areas
  Which part of Acontext would this feature affect?
  - [ ] Client SDK (Python)
  - [ ] Client SDK (TypeScript)
  - [x] Core Service
  - [ ] API Server
  - [ ] Dashboard
  - [ ] CLI Tool
  - [ ] Documentation
  - [ ] Other: ...

  # Checklist
  - [x] Open your pull request against the `dev` branch.
  - [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
  - [ ] Tests are added or modified as needed to cover code changes.