### PR TITLE
fix(dashboard): improve task filter wording to distinguish "No Task" …

### DIFF
--- a/dashboard/app/project/[id]/session/[sessionId]/messages/messages-page-client.tsx
+++ b/dashboard/app/project/[id]/session/[sessionId]/messages/messages-page-client.tsx
@@ -730,12 +730,26 @@ export function MessagesPageClient({
                 )}
               </>
             )}
-            {selectedTaskIds.size > 0 && (
-              <span className="text-xs text-muted-foreground ml-2">
-                Showing {filteredTimelineItems.filter(i => i.kind === 'message').length} of {allMessages.length} messages
-                (filtered by {selectedTaskIds.size} {selectedTaskIds.size === 1 ? 'task' : 'tasks'})
-              </span>
-            )}
+            {selectedTaskIds.size > 0 && (() => {
+              const hasNoTask = selectedTaskIds.has(NO_TASK_SENTINEL);
+              const realTaskCount = selectedTaskIds.size - (hasNoTask ? 1 : 0);
+
+              let filterText = "";
+              if (hasNoTask && realTaskCount > 0) {
+                filterText = ` (filtered by ${realTaskCount} ${realTaskCount === 1 ? 'task' : 'tasks'} + unassigned)`;
+              } else if (hasNoTask) {
+                filterText = " (unassigned only)";
+              } else {
+                filterText = ` (filtered by ${realTaskCount} ${realTaskCount === 1 ? 'task' : 'tasks'})`;
+              }
+
+              return (
+                <span className="text-xs text-muted-foreground ml-2">
+                  Showing {filteredTimelineItems.filter(i => i.kind === 'message').length} of {allMessages.length} messages
+                  {filterText}
+                </span>
+              );
+            })()}
           </div>
         )}
       </div>


### PR DESCRIPTION
  # Why we need this PR?

  The task filter UI was showing misleading text. When user selected "No Task"
  (which filters messages without any task assignment), the UI displayed:
  (filtered by 1 task)
  This was confusing because:
  1. It implied there was 1 real task, but there wasn't
  2. Users thought the filter was broken when they saw "1 task" but no task name

  # Solution

  Now the filter text clearly distinguishes:
  - **"unassigned only"** - when only "No Task" is selected
  - **"filtered by X tasks"** - when only real tasks are selected
  - **"filtered by X tasks + unassigned"** - when both are selected

  # Before
  Showing 5 of 5 messages (filtered by 1 task)  ← confusing!

  # After
  Showing 5 of 5 messages (unassigned only)  ← clear!

# Impact Areas
Which part of Acontext would this feature affect?
- [ ] Client SDK (Python)
- [ ] Client SDK (TypeScript)
- [ ] Core Service
- [ ] API Server
- [x ] Dashboard
- [ ] CLI Tool
- [ ] Documentation
- [ ] Other: ...


# Checklist
- [ ] Open your pull request against the `dev` branch.
- [ ] All tests pass in available continuous integration systems (e.g., GitHub Actions).
- [ ] Tests are added or modified as needed to cover code changes.